### PR TITLE
add more methods

### DIFF
--- a/go/interface.go
+++ b/go/interface.go
@@ -35,15 +35,20 @@ type ServiceInterface interface {
 	GetPillarByName(pillarName string) *Pillar
 	GetTeamGroupByName(teamGroupName string) *TeamGroup
 
+	GetUserMemberships(uid string) []MembershipInfo
+	GetUserTeams(uid string) []string
 	GetTeamsForUID(uid string) []string
 	GetTeamsForSlackID(slackID string) []string
 	GetTeamMembers(teamName string) []Employee
+	GetOrgMembers(orgName string) []Employee
 	IsEmployeeInTeam(uid string, teamName string) bool
 	IsSlackUserInTeam(slackID string, teamName string) bool
 
 	IsEmployeeInOrg(uid string, orgName string) bool
 	IsSlackUserInOrg(slackID string, orgName string) bool
 	GetUserOrganizations(slackUserID string) []OrgInfo
+
+	GetTeamEscalation(teamName string) []EscalationContactInfo
 
 	GetVersion() DataVersion
 	GetDataAge() time.Duration
@@ -53,10 +58,15 @@ type ServiceInterface interface {
 	StopWatcher()
 
 	GetAllEmployeeUIDs() []string
+	GetAllEmployees() []Employee
 	GetAllTeamNames() []string
+	GetAllTeams() []Team
 	GetAllOrgNames() []string
+	GetAllOrgs() []Org
 	GetAllPillarNames() []string
+	GetAllPillars() []Pillar
 	GetAllTeamGroupNames() []string
+	GetAllTeamGroups() []TeamGroup
 
 	// Hierarchy queries
 	GetHierarchyPath(entityName string, entityType string) []HierarchyPathEntry
@@ -66,6 +76,8 @@ type ServiceInterface interface {
 	GetComponentByName(name string) *Component
 	GetAllComponents() []Component
 	GetAllComponentNames() []string
+	GetTeamsForComponent(componentName string) []ComponentOwnerInfo
+	GetComponentsForTeam(teamName string) []ComponentOwnership
 
 	// Jira queries
 	GetJiraProjects() []string

--- a/go/organization_test.go
+++ b/go/organization_test.go
@@ -52,6 +52,40 @@ func TestGetOrgByName(t *testing.T) {
 	}
 }
 
+// TestGetOrgMembers tests organization member retrieval
+func TestGetOrgMembers(t *testing.T) {
+	service := setupTestService(t)
+
+	// test-org has 3 members: jsmith, adoe, bwilson
+	members := service.GetOrgMembers("test-org")
+	if len(members) != 3 {
+		t.Errorf("GetOrgMembers(\"test-org\") returned %d members, expected 3", len(members))
+	}
+
+	// platform-org has 1 member: bwilson
+	members2 := service.GetOrgMembers("platform-org")
+	if len(members2) != 1 {
+		t.Errorf("GetOrgMembers(\"platform-org\") returned %d members, expected 1", len(members2))
+	}
+	if len(members2) > 0 && members2[0].UID != "bwilson" {
+		t.Errorf("GetOrgMembers(\"platform-org\")[0].UID = %q, expected \"bwilson\"", members2[0].UID)
+	}
+
+	// nonexistent org
+	none := service.GetOrgMembers("nonexistent")
+	if len(none) != 0 {
+		t.Errorf("GetOrgMembers(\"nonexistent\") returned %d members, expected 0", len(none))
+	}
+}
+
+func TestGetOrgMembers_EmptyService(t *testing.T) {
+	service := NewService()
+	result := service.GetOrgMembers("test-org")
+	if len(result) != 0 {
+		t.Errorf("Expected 0 members from empty service, got %d", len(result))
+	}
+}
+
 // TestIsEmployeeInOrg tests organization membership checks
 func TestIsEmployeeInOrg(t *testing.T) {
 	service := setupTestService(t)

--- a/go/service.go
+++ b/go/service.go
@@ -847,6 +847,194 @@ func (s *Service) GetJiraOwnershipForTeam(teamName string) []JiraOwnership {
 	return result
 }
 
+// GetUserMemberships returns all memberships for a user.
+func (s *Service) GetUserMemberships(uid string) []MembershipInfo {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Indexes.Membership.MembershipIndex == nil {
+		return []MembershipInfo{}
+	}
+	memberships := s.data.Indexes.Membership.MembershipIndex[uid]
+	if len(memberships) == 0 {
+		return []MembershipInfo{}
+	}
+	result := make([]MembershipInfo, len(memberships))
+	copy(result, memberships)
+	return result
+}
+
+// GetUserTeams returns team names for a user.
+func (s *Service) GetUserTeams(uid string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.getTeamsForUID(uid)
+}
+
+// GetAllEmployees returns all employees.
+func (s *Service) GetAllEmployees() []Employee {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Lookups.Employees == nil {
+		return []Employee{}
+	}
+	employees := make([]Employee, 0, len(s.data.Lookups.Employees))
+	for _, emp := range s.data.Lookups.Employees {
+		employees = append(employees, emp)
+	}
+	return employees
+}
+
+// GetAllTeams returns all teams.
+func (s *Service) GetAllTeams() []Team {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Lookups.Teams == nil {
+		return []Team{}
+	}
+	teams := make([]Team, 0, len(s.data.Lookups.Teams))
+	for _, team := range s.data.Lookups.Teams {
+		teams = append(teams, team)
+	}
+	return teams
+}
+
+// GetAllOrgs returns all organizations.
+func (s *Service) GetAllOrgs() []Org {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Lookups.Orgs == nil {
+		return []Org{}
+	}
+	orgs := make([]Org, 0, len(s.data.Lookups.Orgs))
+	for _, org := range s.data.Lookups.Orgs {
+		orgs = append(orgs, org)
+	}
+	return orgs
+}
+
+// GetAllPillars returns all pillars.
+func (s *Service) GetAllPillars() []Pillar {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Lookups.Pillars == nil {
+		return []Pillar{}
+	}
+	pillars := make([]Pillar, 0, len(s.data.Lookups.Pillars))
+	for _, pillar := range s.data.Lookups.Pillars {
+		pillars = append(pillars, pillar)
+	}
+	return pillars
+}
+
+// GetAllTeamGroups returns all team groups.
+func (s *Service) GetAllTeamGroups() []TeamGroup {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Lookups.TeamGroups == nil {
+		return []TeamGroup{}
+	}
+	tgs := make([]TeamGroup, 0, len(s.data.Lookups.TeamGroups))
+	for _, tg := range s.data.Lookups.TeamGroups {
+		tgs = append(tgs, tg)
+	}
+	return tgs
+}
+
+// GetOrgMembers returns all members of an organization.
+func (s *Service) GetOrgMembers(orgName string) []Employee {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Lookups.Orgs == nil {
+		return []Employee{}
+	}
+	org, exists := s.data.Lookups.Orgs[orgName]
+	if !exists {
+		return []Employee{}
+	}
+	var members []Employee
+	for _, uid := range org.Group.ResolvedPeopleUIDList {
+		if emp, exists := s.data.Lookups.Employees[uid]; exists {
+			members = append(members, emp)
+		}
+	}
+	if members == nil {
+		return []Employee{}
+	}
+	return members
+}
+
+// GetTeamEscalation returns the escalation contacts for a team.
+func (s *Service) GetTeamEscalation(teamName string) []EscalationContactInfo {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Lookups.Teams == nil {
+		return []EscalationContactInfo{}
+	}
+	team, exists := s.data.Lookups.Teams[teamName]
+	if !exists {
+		return []EscalationContactInfo{}
+	}
+	if len(team.Group.Escalation) == 0 {
+		return []EscalationContactInfo{}
+	}
+	result := make([]EscalationContactInfo, len(team.Group.Escalation))
+	copy(result, team.Group.Escalation)
+	return result
+}
+
+// GetTeamsForComponent returns all teams/entities that own a component.
+func (s *Service) GetTeamsForComponent(componentName string) []ComponentOwnerInfo {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Indexes.ComponentOwnership == nil {
+		return []ComponentOwnerInfo{}
+	}
+	owners, exists := s.data.Indexes.ComponentOwnership[componentName]
+	if !exists {
+		return []ComponentOwnerInfo{}
+	}
+	result := make([]ComponentOwnerInfo, len(owners))
+	copy(result, owners)
+	return result
+}
+
+// GetComponentsForTeam returns all components owned by a team.
+func (s *Service) GetComponentsForTeam(teamName string) []ComponentOwnership {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.data.Indexes.ComponentOwnership == nil {
+		return []ComponentOwnership{}
+	}
+
+	var result []ComponentOwnership
+	for componentName, owners := range s.data.Indexes.ComponentOwnership {
+		for _, owner := range owners {
+			if owner.Name == teamName {
+				result = append(result, ComponentOwnership{
+					Component:      componentName,
+					OwnershipTypes: owner.OwnershipTypes,
+				})
+				break
+			}
+		}
+	}
+	if result == nil {
+		return []ComponentOwnership{}
+	}
+	return result
+}
+
 // validateData checks that required data structures are present.
 func validateData(data *Data) error {
 	if len(data.Lookups.Employees) == 0 {

--- a/go/service_edge_cases_test.go
+++ b/go/service_edge_cases_test.go
@@ -415,6 +415,96 @@ func TestGetAllOrgNames_EmptyService(t *testing.T) {
 	}
 }
 
+// TestGetAllEmployees tests bulk employee retrieval
+func TestGetAllEmployees(t *testing.T) {
+	service := setupTestService(t)
+
+	employees := service.GetAllEmployees()
+	if len(employees) != 3 {
+		t.Errorf("GetAllEmployees() returned %d employees, expected 3", len(employees))
+	}
+}
+
+func TestGetAllEmployees_EmptyService(t *testing.T) {
+	service := NewService()
+	employees := service.GetAllEmployees()
+	if len(employees) != 0 {
+		t.Errorf("Expected 0 employees from empty service, got %d", len(employees))
+	}
+}
+
+// TestGetAllTeams tests bulk team retrieval
+func TestGetAllTeams(t *testing.T) {
+	service := setupTestService(t)
+
+	teams := service.GetAllTeams()
+	if len(teams) != 2 {
+		t.Errorf("GetAllTeams() returned %d teams, expected 2", len(teams))
+	}
+}
+
+func TestGetAllTeams_EmptyService(t *testing.T) {
+	service := NewService()
+	teams := service.GetAllTeams()
+	if len(teams) != 0 {
+		t.Errorf("Expected 0 teams from empty service, got %d", len(teams))
+	}
+}
+
+// TestGetAllOrgs tests bulk org retrieval
+func TestGetAllOrgs(t *testing.T) {
+	service := setupTestService(t)
+
+	orgs := service.GetAllOrgs()
+	if len(orgs) != 2 {
+		t.Errorf("GetAllOrgs() returned %d orgs, expected 2", len(orgs))
+	}
+}
+
+func TestGetAllOrgs_EmptyService(t *testing.T) {
+	service := NewService()
+	orgs := service.GetAllOrgs()
+	if len(orgs) != 0 {
+		t.Errorf("Expected 0 orgs from empty service, got %d", len(orgs))
+	}
+}
+
+// TestGetAllPillars tests bulk pillar retrieval
+func TestGetAllPillars(t *testing.T) {
+	service := setupTestService(t)
+
+	pillars := service.GetAllPillars()
+	if len(pillars) != 1 {
+		t.Errorf("GetAllPillars() returned %d pillars, expected 1", len(pillars))
+	}
+}
+
+func TestGetAllPillars_EmptyService(t *testing.T) {
+	service := NewService()
+	pillars := service.GetAllPillars()
+	if len(pillars) != 0 {
+		t.Errorf("Expected 0 pillars from empty service, got %d", len(pillars))
+	}
+}
+
+// TestGetAllTeamGroups tests bulk team group retrieval
+func TestGetAllTeamGroups(t *testing.T) {
+	service := setupTestService(t)
+
+	tgs := service.GetAllTeamGroups()
+	if len(tgs) != 1 {
+		t.Errorf("GetAllTeamGroups() returned %d team groups, expected 1", len(tgs))
+	}
+}
+
+func TestGetAllTeamGroups_EmptyService(t *testing.T) {
+	service := NewService()
+	tgs := service.GetAllTeamGroups()
+	if len(tgs) != 0 {
+		t.Errorf("Expected 0 team groups from empty service, got %d", len(tgs))
+	}
+}
+
 // TestStartDataSourceWatcher tests watcher functionality
 func TestStartDataSourceWatcher_AlreadyRunning(t *testing.T) {
 	service := NewService()

--- a/go/team_test.go
+++ b/go/team_test.go
@@ -325,6 +325,146 @@ func TestTeamMembershipConsistency(t *testing.T) {
 	}
 }
 
+// TestGetUserMemberships tests membership lookup by UID
+func TestGetUserMemberships(t *testing.T) {
+	service := setupTestService(t)
+
+	tests := []struct {
+		name     string
+		uid      string
+		minCount int
+	}{
+		{"jsmith memberships", "jsmith", 2},
+		{"bwilson memberships", "bwilson", 2},
+		{"nonexistent user", "nonexistent", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.GetUserMemberships(tt.uid)
+			if len(result) < tt.minCount {
+				t.Errorf("GetUserMemberships(%q) returned %d items, expected at least %d", tt.uid, len(result), tt.minCount)
+			}
+		})
+	}
+}
+
+func TestGetUserMemberships_EmptyService(t *testing.T) {
+	service := NewService()
+	result := service.GetUserMemberships("jsmith")
+	if len(result) != 0 {
+		t.Errorf("Expected 0 memberships from empty service, got %d", len(result))
+	}
+}
+
+// TestGetUserTeams tests GetUserTeams (alias for GetTeamsForUID)
+func TestGetUserTeams(t *testing.T) {
+	service := setupTestService(t)
+
+	teams := service.GetUserTeams("jsmith")
+	found := false
+	for _, team := range teams {
+		if team == "test-team" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GetUserTeams(\"jsmith\") = %v, expected to contain \"test-team\"", teams)
+	}
+
+	empty := service.GetUserTeams("nonexistent")
+	if len(empty) != 0 {
+		t.Errorf("GetUserTeams(\"nonexistent\") = %v, expected empty", empty)
+	}
+}
+
+// TestGetTeamEscalation tests escalation contact retrieval
+func TestGetTeamEscalation(t *testing.T) {
+	service := setupTestService(t)
+
+	// platform-team has escalation contacts in test data
+	contacts := service.GetTeamEscalation("platform-team")
+	if len(contacts) != 2 {
+		t.Errorf("GetTeamEscalation(\"platform-team\") returned %d contacts, expected 2", len(contacts))
+	}
+	if len(contacts) > 0 && contacts[0].Name != "Platform on-call" {
+		t.Errorf("First escalation contact name = %q, expected \"Platform on-call\"", contacts[0].Name)
+	}
+
+	// test-team has no escalation contacts
+	noContacts := service.GetTeamEscalation("test-team")
+	if len(noContacts) != 0 {
+		t.Errorf("GetTeamEscalation(\"test-team\") returned %d contacts, expected 0", len(noContacts))
+	}
+
+	// nonexistent team
+	none := service.GetTeamEscalation("nonexistent")
+	if len(none) != 0 {
+		t.Errorf("GetTeamEscalation(\"nonexistent\") returned %d contacts, expected 0", len(none))
+	}
+}
+
+func TestGetTeamEscalation_EmptyService(t *testing.T) {
+	service := NewService()
+	result := service.GetTeamEscalation("test-team")
+	if len(result) != 0 {
+		t.Errorf("Expected 0 escalation contacts from empty service, got %d", len(result))
+	}
+}
+
+// TestGetTeamsForComponent tests component ownership lookup
+func TestGetTeamsForComponent(t *testing.T) {
+	service := setupTestService(t)
+
+	// auth-service is owned by two teams
+	owners := service.GetTeamsForComponent("auth-service")
+	if len(owners) != 2 {
+		t.Errorf("GetTeamsForComponent(\"auth-service\") returned %d owners, expected 2", len(owners))
+	}
+
+	// platform-api is owned by one team
+	owners2 := service.GetTeamsForComponent("platform-api")
+	if len(owners2) != 1 {
+		t.Errorf("GetTeamsForComponent(\"platform-api\") returned %d owners, expected 1", len(owners2))
+	}
+	if len(owners2) > 0 && owners2[0].Name != "platform-team" {
+		t.Errorf("GetTeamsForComponent(\"platform-api\")[0].Name = %q, expected \"platform-team\"", owners2[0].Name)
+	}
+
+	// nonexistent component
+	none := service.GetTeamsForComponent("nonexistent")
+	if len(none) != 0 {
+		t.Errorf("GetTeamsForComponent(\"nonexistent\") returned %d owners, expected 0", len(none))
+	}
+}
+
+// TestGetComponentsForTeam tests reverse component ownership lookup
+func TestGetComponentsForTeam(t *testing.T) {
+	service := setupTestService(t)
+
+	// platform-team owns platform-api and auth-service
+	components := service.GetComponentsForTeam("platform-team")
+	if len(components) != 2 {
+		t.Errorf("GetComponentsForTeam(\"platform-team\") returned %d components, expected 2", len(components))
+	}
+
+	// test-team owns auth-service
+	components2 := service.GetComponentsForTeam("test-team")
+	if len(components2) != 1 {
+		t.Errorf("GetComponentsForTeam(\"test-team\") returned %d components, expected 1", len(components2))
+	}
+	if len(components2) > 0 && components2[0].Component != "auth-service" {
+		t.Errorf("GetComponentsForTeam(\"test-team\")[0].Component = %q, expected \"auth-service\"", components2[0].Component)
+	}
+
+	// nonexistent team
+	none := service.GetComponentsForTeam("nonexistent")
+	if len(none) != 0 {
+		t.Errorf("GetComponentsForTeam(\"nonexistent\") returned %d components, expected 0", len(none))
+	}
+}
+
 // TestGroupExtendedFields tests the extended Group fields added in refactoring
 func TestGroupExtendedFields(t *testing.T) {
 	service := NewService()
@@ -394,12 +534,7 @@ func TestGroupExtendedFields(t *testing.T) {
 								Description: "Team wiki",
 							},
 						},
-						ComponentRoles: []ComponentRoleInfo{
-							{
-								Component: "/component/path",
-								Types:     []string{"owner"},
-							},
-						},
+						ComponentRoles: []string{"/component/path"},
 					},
 				},
 			},

--- a/go/types.go
+++ b/go/types.go
@@ -81,6 +81,26 @@ type ResourceInfo struct {
 	Description string `json:"description,omitempty"`
 }
 
+// EscalationContactInfo represents an escalation contact for incident response
+type EscalationContactInfo struct {
+	Name        string `json:"name"`
+	URL         string `json:"url,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// ComponentOwnerInfo represents an entity that owns a component, with ownership types
+type ComponentOwnerInfo struct {
+	Name           string   `json:"name"`
+	Type           string   `json:"type"`
+	OwnershipTypes []string `json:"ownership_types"`
+}
+
+// ComponentOwnership represents a component owned by a team, with ownership types
+type ComponentOwnership struct {
+	Component      string   `json:"component"`
+	OwnershipTypes []string `json:"ownership_types"`
+}
+
 // ComponentRoleInfo represents component ownership information
 type ComponentRoleInfo struct {
 	Component string   `json:"component"`
@@ -114,8 +134,9 @@ type Group struct {
 	Repos                 []RepoInfo          `json:"repos,omitempty"`
 	Keywords              []string            `json:"keywords,omitempty"`
 	Emails                []EmailInfo         `json:"emails,omitempty"`
-	Resources             []ResourceInfo      `json:"resources,omitempty"`
-	ComponentRoles        []ComponentRoleInfo `json:"component_roles,omitempty"`
+	Resources             []ResourceInfo         `json:"resources,omitempty"`
+	Escalation            []EscalationContactInfo `json:"escalation,omitempty"`
+	ComponentRoles        []string               `json:"component_roles,omitempty"`
 }
 
 // GroupType contains group type information
@@ -253,10 +274,11 @@ func (c *Component) UnmarshalJSON(data []byte) error {
 
 // Indexes contains pre-computed lookup tables
 type Indexes struct {
-	Membership       MembershipIndex  `json:"membership"`
-	SlackIDMappings  SlackIDMappings  `json:"slack_id_mappings"`
-	GitHubIDMappings GitHubIDMappings `json:"github_id_mappings,omitempty"`
-	Jira             JiraIndex        `json:"jira,omitempty"`
+	Membership         MembershipIndex                  `json:"membership"`
+	SlackIDMappings    SlackIDMappings                  `json:"slack_id_mappings"`
+	GitHubIDMappings   GitHubIDMappings                 `json:"github_id_mappings,omitempty"`
+	Jira               JiraIndex                        `json:"jira,omitempty"`
+	ComponentOwnership map[string][]ComponentOwnerInfo   `json:"component_ownership,omitempty"`
 }
 
 // SlackIDMappings contains Slack ID to UID mappings

--- a/parity/go_runner/main.go
+++ b/parity/go_runner/main.go
@@ -196,6 +196,12 @@ var methodParamNames = map[string][]string{
 	"GetJiraComponents":      {"project"},
 	"GetTeamsByJiraProject":  {"project"},
 	"GetJiraOwnershipForTeam": {"team_name"},
+	"GetUserMemberships":     {"uid"},
+	"GetUserTeams":           {"uid"},
+	"GetOrgMembers":          {"org_name"},
+	"GetTeamEscalation":      {"team_name"},
+	"GetTeamsForComponent":   {"component_name"},
+	"GetComponentsForTeam":   {"team_name"},
 	"IsEmployeeInTeam":       {"uid", "team_name"},
 	"IsSlackUserInTeam":      {"slack_id", "team_name"},
 	"IsEmployeeInOrg":        {"uid", "org_name"},
@@ -316,6 +322,22 @@ func serializeOutput(output interface{}) interface{} {
 		return serializeJiraOwnerList(val)
 	case []orgdatacore.JiraOwnership:
 		return serializeJiraOwnershipList(val)
+	case []orgdatacore.Team:
+		return serializeTeamList(val)
+	case []orgdatacore.Org:
+		return serializeOrgList(val)
+	case []orgdatacore.Pillar:
+		return serializePillarList(val)
+	case []orgdatacore.TeamGroup:
+		return serializeTeamGroupList(val)
+	case []orgdatacore.MembershipInfo:
+		return serializeMembershipInfoList(val)
+	case []orgdatacore.EscalationContactInfo:
+		return serializeEscalationList(val)
+	case []orgdatacore.ComponentOwnerInfo:
+		return serializeComponentOwnerInfoList(val)
+	case []orgdatacore.ComponentOwnership:
+		return serializeComponentOwnershipList(val)
 	default:
 		return output
 	}
@@ -495,6 +517,128 @@ func serializeJiraOwnershipList(ownerships []orgdatacore.JiraOwnership) interfac
 		if result[i]["project"].(string) != result[j]["project"].(string) {
 			return result[i]["project"].(string) < result[j]["project"].(string)
 		}
+		return result[i]["component"].(string) < result[j]["component"].(string)
+	})
+	return result
+}
+
+func serializeTeamList(teams []orgdatacore.Team) interface{} {
+	result := make([]map[string]interface{}, len(teams))
+	for i, team := range teams {
+		result[i] = map[string]interface{}{
+			"uid":         team.UID,
+			"name":        team.Name,
+			"description": team.Description,
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i]["name"].(string) < result[j]["name"].(string)
+	})
+	return result
+}
+
+func serializeOrgList(orgs []orgdatacore.Org) interface{} {
+	result := make([]map[string]interface{}, len(orgs))
+	for i, org := range orgs {
+		result[i] = map[string]interface{}{
+			"uid":         org.UID,
+			"name":        org.Name,
+			"description": org.Description,
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i]["name"].(string) < result[j]["name"].(string)
+	})
+	return result
+}
+
+func serializePillarList(pillars []orgdatacore.Pillar) interface{} {
+	result := make([]map[string]interface{}, len(pillars))
+	for i, pillar := range pillars {
+		result[i] = map[string]interface{}{
+			"uid":         pillar.UID,
+			"name":        pillar.Name,
+			"description": pillar.Description,
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i]["name"].(string) < result[j]["name"].(string)
+	})
+	return result
+}
+
+func serializeTeamGroupList(tgs []orgdatacore.TeamGroup) interface{} {
+	result := make([]map[string]interface{}, len(tgs))
+	for i, tg := range tgs {
+		result[i] = map[string]interface{}{
+			"uid":         tg.UID,
+			"name":        tg.Name,
+			"description": tg.Description,
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i]["name"].(string) < result[j]["name"].(string)
+	})
+	return result
+}
+
+func serializeMembershipInfoList(infos []orgdatacore.MembershipInfo) interface{} {
+	result := make([]map[string]interface{}, len(infos))
+	for i, info := range infos {
+		result[i] = map[string]interface{}{
+			"name": info.Name,
+			"type": info.Type,
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i]["name"].(string) != result[j]["name"].(string) {
+			return result[i]["name"].(string) < result[j]["name"].(string)
+		}
+		return result[i]["type"].(string) < result[j]["type"].(string)
+	})
+	return result
+}
+
+func serializeEscalationList(contacts []orgdatacore.EscalationContactInfo) interface{} {
+	result := make([]map[string]interface{}, len(contacts))
+	for i, contact := range contacts {
+		result[i] = map[string]interface{}{
+			"name":        contact.Name,
+			"url":         contact.URL,
+			"description": contact.Description,
+		}
+	}
+	// Escalation order matters (it's priority order), so don't sort
+	return result
+}
+
+func serializeComponentOwnerInfoList(owners []orgdatacore.ComponentOwnerInfo) interface{} {
+	result := make([]map[string]interface{}, len(owners))
+	for i, owner := range owners {
+		result[i] = map[string]interface{}{
+			"name":            owner.Name,
+			"type":            owner.Type,
+			"ownership_types": owner.OwnershipTypes,
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i]["name"].(string) != result[j]["name"].(string) {
+			return result[i]["name"].(string) < result[j]["name"].(string)
+		}
+		return result[i]["type"].(string) < result[j]["type"].(string)
+	})
+	return result
+}
+
+func serializeComponentOwnershipList(ownerships []orgdatacore.ComponentOwnership) interface{} {
+	result := make([]map[string]interface{}, len(ownerships))
+	for i, ownership := range ownerships {
+		result[i] = map[string]interface{}{
+			"component":      ownership.Component,
+			"ownership_types": ownership.OwnershipTypes,
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
 		return result[i]["component"].(string) < result[j]["component"].(string)
 	})
 	return result

--- a/parity/python_runner/runner.py
+++ b/parity/python_runner/runner.py
@@ -6,15 +6,86 @@ Accepts method configuration via stdin and outputs JSON results.
 
 import json
 import sys
-from dataclasses import asdict, is_dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "python"))
 
+from pydantic import BaseModel
+
 from orgdatacore import Service  # noqa: E402
 from orgdatacore._internal.testing import FileDataSource  # noqa: E402
+
+
+@dataclass(frozen=True, slots=True)
+class EntityConfig:
+    """Defines which fields to serialize and how to sort for a given entity type."""
+
+    fields: tuple[str, ...]
+    sort_by: tuple[str, ...] = ()
+    preserve_order: bool = False
+
+
+ENTITY_REGISTRY: dict[str, EntityConfig] = {
+    "Employee": EntityConfig(
+        fields=("uid", "full_name", "email"),
+        sort_by=("uid",),
+    ),
+    "Team": EntityConfig(
+        fields=("uid", "name", "description"),
+        sort_by=("name",),
+    ),
+    "Org": EntityConfig(
+        fields=("uid", "name", "description"),
+        sort_by=("name",),
+    ),
+    "Pillar": EntityConfig(
+        fields=("uid", "name", "description"),
+        sort_by=("name",),
+    ),
+    "TeamGroup": EntityConfig(
+        fields=("uid", "name", "description"),
+        sort_by=("name",),
+    ),
+    "Component": EntityConfig(
+        fields=("name", "description"),
+        sort_by=("name",),
+    ),
+    "HierarchyPathEntry": EntityConfig(
+        fields=("name", "type"),
+        preserve_order=True,
+    ),
+    "OrgInfo": EntityConfig(
+        fields=("name", "type"),
+        sort_by=("name",),
+    ),
+    "JiraOwnerInfo": EntityConfig(
+        fields=("name", "type"),
+        sort_by=("name",),
+    ),
+    "JiraOwnership": EntityConfig(
+        fields=("project", "component"),
+        sort_by=("project", "component"),
+    ),
+    "MembershipInfo": EntityConfig(
+        fields=("name", "type"),
+        sort_by=("name", "type"),
+    ),
+    "EscalationContactInfo": EntityConfig(
+        fields=("name", "url", "description"),
+        preserve_order=True,
+    ),
+    "ComponentOwnerInfo": EntityConfig(
+        fields=("name", "type", "ownership_types"),
+        sort_by=("name", "type"),
+    ),
+    "ComponentOwnership": EntityConfig(
+        fields=("component", "ownership_types"),
+        sort_by=("component",),
+    ),
+}
 
 
 def main() -> None:
@@ -82,9 +153,9 @@ def serialize_output(output: Any) -> Any:
         return output
     if isinstance(output, (list, tuple)) and all(isinstance(x, str) for x in output):
         return sorted(output)
-    if isinstance(output, (list, tuple)) and output and is_dataclass(output[0]):
+    if isinstance(output, (list, tuple)) and output and isinstance(output[0], BaseModel):
         return serialize_entity_list(list(output))
-    if is_dataclass(output) and not isinstance(output, type):
+    if isinstance(output, BaseModel):
         return serialize_entity(output)
     if isinstance(output, dict):
         return output
@@ -95,66 +166,18 @@ def serialize_entity(entity: Any) -> dict[str, Any]:
     """Serialize a dataclass entity to match Go output format."""
     entity_type = type(entity).__name__
 
-    if entity_type == "Employee":
-        return {
-            "uid": entity.uid,
-            "full_name": entity.full_name,
-            "email": entity.email,
-        }
-    elif entity_type == "Team":
-        return {
-            "uid": entity.uid,
-            "name": entity.name,
-            "description": entity.description,
-        }
-    elif entity_type == "Org":
-        return {
-            "uid": entity.uid,
-            "name": entity.name,
-            "description": entity.description,
-        }
-    elif entity_type == "Pillar":
-        return {
-            "uid": entity.uid,
-            "name": entity.name,
-            "description": entity.description,
-        }
-    elif entity_type == "TeamGroup":
-        return {
-            "uid": entity.uid,
-            "name": entity.name,
-            "description": entity.description,
-        }
-    elif entity_type == "Component":
-        return {
-            "name": entity.name,
-            "description": entity.description,
-        }
-    elif entity_type == "HierarchyPathEntry":
-        return {
-            "name": entity.name,
-            "type": entity.type,
-        }
-    elif entity_type == "HierarchyNode":
+    if entity_type == "HierarchyNode":
         return serialize_hierarchy_node(entity)
-    elif entity_type == "OrgInfo":
-        return {
-            "name": entity.name,
-            "type": entity.type,
-        }
-    elif entity_type == "JiraOwnerInfo":
-        return {
-            "name": entity.name,
-            "type": entity.type,
-        }
-    elif entity_type == "JiraOwnership":
-        return {
-            "project": entity.project,
-            "component": entity.component,
-        }
-    else:
-        # Generic dataclass serialization
-        return asdict(entity)
+
+    config = ENTITY_REGISTRY.get(entity_type)
+    if config is not None:
+        d: dict[str, Any] = {}
+        for field_name in config.fields:
+            val = getattr(entity, field_name)
+            d[field_name] = list(val) if isinstance(val, tuple) else val
+        return d
+
+    return entity.model_dump()
 
 
 def serialize_entity_list(entities: list[Any]) -> list[dict[str, Any]]:
@@ -165,18 +188,14 @@ def serialize_entity_list(entities: list[Any]) -> list[dict[str, Any]]:
     result = [serialize_entity(e) for e in entities]
     entity_type = type(entities[0]).__name__
 
-    if entity_type == "Employee":
-        result.sort(key=lambda x: x.get("uid", ""))
-    elif entity_type in ("Team", "Org", "Pillar", "TeamGroup", "Component", "OrgInfo", "JiraOwnerInfo"):
-        result.sort(key=lambda x: x.get("name", ""))
-    elif entity_type == "JiraOwnership":
-        result.sort(key=lambda x: (x.get("project", ""), x.get("component", "")))
-    elif entity_type == "HierarchyPathEntry":
-        pass  # Order matters for hierarchy paths
-    elif result and "uid" in result[0]:
-        result.sort(key=lambda x: x.get("uid", ""))
-    elif result and "name" in result[0]:
-        result.sort(key=lambda x: x.get("name", ""))
+    config = ENTITY_REGISTRY.get(entity_type)
+    if config is not None and not config.preserve_order and config.sort_by:
+        result.sort(key=lambda x: tuple(x.get(k, "") for k in config.sort_by))
+    elif config is None:
+        if result and "uid" in result[0]:
+            result.sort(key=lambda x: x.get("uid", ""))
+        elif result and "name" in result[0]:
+            result.sort(key=lambda x: x.get("name", ""))
 
     return result
 
@@ -189,9 +208,9 @@ def serialize_hierarchy_node(node: Any) -> dict[str, Any]:
 
 
 def json_serializer(obj: Any) -> Any:
-    """Custom JSON serializer for dataclasses."""
-    if is_dataclass(obj) and not isinstance(obj, type):
-        return asdict(obj)
+    """Custom JSON serializer for pydantic models."""
+    if isinstance(obj, BaseModel):
+        return obj.model_dump()
     raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -163,23 +163,23 @@ def get_teams_for_uid(self, uid: str) -> list[str]:
 
 ## Adding a New Entity Type
 
-1. Add dataclass to `_types.py`:
+1. Add model to `_types.py`:
 ```python
-@dataclass(frozen=True, slots=True)
-class NewEntity:
+class NewEntity(BaseModel):
     """Represents a new entity in the organizational data."""
+
+    model_config = ConfigDict(frozen=True)
 
     uid: str = ""
     name: str = ""
     # ... fields match JSON structure
 ```
 
-2. Add to `Lookups` dataclass:
+2. Add to `Lookups` model:
 ```python
-@dataclass(frozen=True, slots=True)
-class Lookups:
+class Lookups(BaseModel):
     # ... existing fields ...
-    new_entities: dict[str, NewEntity] = field(default_factory=dict)
+    new_entities: dict[str, NewEntity] = Field(default_factory=dict)
 ```
 
 3. Add parser function in `_service.py`:
@@ -202,21 +202,21 @@ def _parse_new_entity(data: dict[str, Any]) -> NewEntity:
 
 For new external ID → UID mappings:
 
-1. Add mapping dataclass to `_types.py`:
+1. Add mapping model to `_types.py`:
 ```python
-@dataclass(frozen=True, slots=True)
-class NewIDMappings:
+class NewIDMappings(BaseModel):
     """Contains New ID to UID mappings."""
 
-    new_id_to_uid: dict[str, str] = field(default_factory=dict)
+    model_config = ConfigDict(frozen=True)
+
+    new_id_to_uid: dict[str, str] = Field(default_factory=dict)
 ```
 
-2. Add to `Indexes` dataclass:
+2. Add to `Indexes` model:
 ```python
-@dataclass(frozen=True, slots=True)
-class Indexes:
+class Indexes(BaseModel):
     # ... existing fields ...
-    new_id_mappings: NewIDMappings = field(default_factory=NewIDMappings)
+    new_id_mappings: NewIDMappings = Field(default_factory=NewIDMappings)
 ```
 
 3. Update `_parse_data()` to parse the new mappings
@@ -234,25 +234,27 @@ def get_employee_by_uid(self, uid: str) -> Employee | None:
 # Correct: List for collections
 def get_all_team_names(self) -> list[str]:
 
-# Correct: Tuple for immutable sequences in dataclasses
-@dataclass(frozen=True, slots=True)
-class SlackConfig:
+# Correct: Tuple for immutable sequences in models
+class SlackConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
     channels: tuple[ChannelInfo, ...] = ()
 ```
 
-## Dataclass Conventions
+## Pydantic Model Conventions
 
-Always use frozen, slotted dataclasses:
+Always use frozen pydantic BaseModel:
 ```python
-@dataclass(frozen=True, slots=True)
-class Employee:
+class Employee(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     uid: str = ""
     full_name: str = ""
     # Default values for all fields
 ```
 
 - `frozen=True`: Immutability for thread safety
-- `slots=True`: Memory efficiency
+- Only add `populate_by_name=True` if the model has aliased fields (`Field(alias=...)`)
+- Use `Field(default_factory=...)` for mutable defaults (dicts, lists)
 
 ## Protocol-Based DataSource
 

--- a/python/orgdatacore/__init__.py
+++ b/python/orgdatacore/__init__.py
@@ -6,7 +6,7 @@ access to organizational data including employees, teams, organizations,
 pillars, and team groups.
 
 Example with GCS:
-    from orgdatacore import Service, GCSConfig, GCSDataSourceWithSDK
+    from orgdatacore import Service, GCSConfig, GCSDataSource
     from datetime import timedelta
 
     config = GCSConfig(
@@ -15,7 +15,7 @@ Example with GCS:
         project_id="your-project",
         check_interval=timedelta(minutes=5),
     )
-    source = GCSDataSourceWithSDK(config)
+    source = GCSDataSource(config)
 
     service = Service()
     service.load_from_data_source(source)
@@ -31,7 +31,7 @@ Example with custom DataSource:
 """
 
 from ._anonymization import AnonymizingDataSource, AsyncAnonymizingDataSource
-from ._async import AsyncService
+from ._async import AsyncGCSDataSource, AsyncService
 from ._exceptions import (
     ConfigurationError,
     DataLoadError,
@@ -41,17 +41,21 @@ from ._exceptions import (
 )
 from ._gcs import GCSDataSource
 from ._log import configure_default_logging, get_logger, set_logger
-from ._redaction import RedactingDataSource
+from ._redaction import AsyncRedactingDataSource, RedactingDataSource
 from ._service import Service
 from ._types import (
     AliasInfo,
     ChannelInfo,
-    ComponentRoleInfo,
+    Component,
+    ComponentOwnerInfo,
+    ComponentOwnership,
+    ComponentOwnershipIndex,
     Data,
     DataSource,
     DataVersion,
     EmailInfo,
     Employee,
+    EscalationContactInfo,
     GCSConfig,
     GitHubIDMappings,
     Group,
@@ -89,16 +93,10 @@ from ._version import (
     get_version_dict,
 )
 
-try:
-    from ._async import AsyncGCSDataSource
-    from ._gcs import GCSDataSourceWithSDK
-except ImportError:
-    GCSDataSourceWithSDK = None  # type: ignore[misc, assignment]
-    AsyncGCSDataSource = None  # type: ignore[misc, assignment]
-
 __all__ = [
     "AnonymizingDataSource",
     "AsyncAnonymizingDataSource",
+    "AsyncRedactingDataSource",
     "Employee",
     "Team",
     "Org",
@@ -126,8 +124,12 @@ __all__ = [
     "JiraInfo",
     "RepoInfo",
     "EmailInfo",
+    "EscalationContactInfo",
     "ResourceInfo",
-    "ComponentRoleInfo",
+    "Component",
+    "ComponentOwnerInfo",
+    "ComponentOwnership",
+    "ComponentOwnershipIndex",
     "OrgInfo",
     "DataVersion",
     "GCSConfig",
@@ -139,7 +141,6 @@ __all__ = [
     "Service",
     "AsyncService",
     "GCSDataSource",
-    "GCSDataSourceWithSDK",
     "AsyncGCSDataSource",
     "OrgDataError",
     "DataLoadError",

--- a/python/orgdatacore/_anonymization.py
+++ b/python/orgdatacore/_anonymization.py
@@ -8,7 +8,6 @@ existing UIDs keep their nonces, new UIDs get fresh random nonces.
 
 import json
 import secrets
-from dataclasses import replace
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, BinaryIO
 
@@ -16,6 +15,7 @@ from ._serialization import data_to_json_bytes
 from ._service import parse_data
 from ._types import (
     Data,
+    Employee,
     GitHubIDMappings,
     Group,
     MembershipIndex,
@@ -102,15 +102,15 @@ class _AnonymizationEngine:
         self._github_id_to_nonce = {}
 
         used_nonces: set[str] = set(
-            prev_uid_to_nonce[uid]
-            for uid in employees
-            if uid in prev_uid_to_nonce
+            prev_uid_to_nonce[uid] for uid in employees if uid in prev_uid_to_nonce
         )
 
         # Phase 1: Build UID -> nonce mapping for all employees
         for uid, emp in employees.items():
             # Reuse existing nonce if available, otherwise generate new one
-            nonce = prev_uid_to_nonce.get(uid) or self._generate_nonce("HUMAN-", used_nonces)
+            nonce = prev_uid_to_nonce.get(uid) or self._generate_nonce(
+                "HUMAN-", used_nonces
+            )
             self._uid_to_nonce[uid] = nonce
             self._nonce_to_uid[nonce] = uid
 
@@ -155,7 +155,7 @@ class _AnonymizationEngine:
                 uid_to_github_nonce[uid] = self._github_id_to_nonce[github_id]
 
         # Phase 3: Rewrite employee records
-        new_employees: dict[str, Any] = {}
+        new_employees: dict[str, Employee] = {}
         for uid, emp in employees.items():
             nonce = self._uid_to_nonce[uid]
 
@@ -163,14 +163,15 @@ class _AnonymizationEngine:
             if emp.manager_uid:
                 manager_nonce = self._uid_to_nonce.get(emp.manager_uid, "")
 
-            new_employees[nonce] = replace(
-                emp,
-                uid=nonce,
-                full_name="[ANONYMIZED]",
-                email="[ANONYMIZED]",
-                slack_uid=uid_to_slack_nonce.get(uid, ""),
-                github_id=uid_to_github_nonce.get(uid, ""),
-                manager_uid=manager_nonce,
+            new_employees[nonce] = emp.model_copy(
+                update={
+                    "uid": nonce,
+                    "full_name": "[ANONYMIZED]",
+                    "email": "[ANONYMIZED]",
+                    "slack_uid": uid_to_slack_nonce.get(uid, ""),
+                    "github_id": uid_to_github_nonce.get(uid, ""),
+                    "manager_uid": manager_nonce,
+                }
             )
 
         # Phase 4: Rewrite indexes
@@ -197,38 +198,55 @@ class _AnonymizationEngine:
 
         # Phase 5: Rewrite group people lists in teams/orgs/pillars/team_groups
         new_teams = {
-            name: replace(t, group=_remap_group(t.group, self._uid_to_nonce))
+            name: t.model_copy(
+                update={"group": _remap_group(t.group, self._uid_to_nonce)}
+            )
             for name, t in data.lookups.teams.items()
         }
         new_orgs = {
-            name: replace(o, group=_remap_group(o.group, self._uid_to_nonce))
+            name: o.model_copy(
+                update={"group": _remap_group(o.group, self._uid_to_nonce)}
+            )
             for name, o in data.lookups.orgs.items()
         }
         new_pillars = {
-            name: replace(p, group=_remap_group(p.group, self._uid_to_nonce))
+            name: p.model_copy(
+                update={"group": _remap_group(p.group, self._uid_to_nonce)}
+            )
             for name, p in data.lookups.pillars.items()
         }
         new_team_groups = {
-            name: replace(tg, group=_remap_group(tg.group, self._uid_to_nonce))
+            name: tg.model_copy(
+                update={"group": _remap_group(tg.group, self._uid_to_nonce)}
+            )
             for name, tg in data.lookups.team_groups.items()
         }
 
-        return replace(
-            data,
-            lookups=replace(
-                data.lookups,
-                employees=new_employees,
-                teams=new_teams,
-                orgs=new_orgs,
-                pillars=new_pillars,
-                team_groups=new_team_groups,
-            ),
-            indexes=replace(
-                data.indexes,
-                membership=MembershipIndex(membership_index=new_membership_index),
-                slack_id_mappings=SlackIDMappings(slack_uid_to_uid=new_slack_index),
-                github_id_mappings=GitHubIDMappings(github_id_to_uid=new_github_index),
-            ),
+        return data.model_copy(
+            update={
+                "lookups": data.lookups.model_copy(
+                    update={
+                        "employees": new_employees,
+                        "teams": new_teams,
+                        "orgs": new_orgs,
+                        "pillars": new_pillars,
+                        "team_groups": new_team_groups,
+                    }
+                ),
+                "indexes": data.indexes.model_copy(
+                    update={
+                        "membership": MembershipIndex(
+                            membership_index=new_membership_index
+                        ),
+                        "slack_id_mappings": SlackIDMappings(
+                            slack_uid_to_uid=new_slack_index
+                        ),
+                        "github_id_mappings": GitHubIDMappings(
+                            github_id_to_uid=new_github_index
+                        ),
+                    }
+                ),
+            }
         )
 
 
@@ -237,14 +255,39 @@ def _remap_group(group: Group, uid_to_nonce: dict[str, str]) -> Group:
     new_people = tuple(
         uid_to_nonce.get(uid, uid) for uid in group.resolved_people_uid_list
     )
-    new_roles = tuple(
-        replace(
-            role,
-            people=tuple(uid_to_nonce.get(uid, uid) for uid in role.people),
+    new_roles = (
+        tuple(
+            role.model_copy(
+                update={
+                    "people": tuple(uid_to_nonce.get(uid, uid) for uid in role.people)
+                }
+            )
+            for role in group.roles
         )
-        for role in group.roles
-    ) if group.roles else ()
-    return replace(group, resolved_people_uid_list=new_people, roles=new_roles)
+        if group.roles
+        else ()
+    )
+    new_escalation = (
+        tuple(
+            contact.model_copy(
+                update={
+                    "name": "[ANONYMIZED]",
+                    "url": "",
+                    "description": "[ANONYMIZED]",
+                }
+            )
+            for contact in group.escalation
+        )
+        if group.escalation
+        else ()
+    )
+    return group.model_copy(
+        update={
+            "resolved_people_uid_list": new_people,
+            "roles": new_roles,
+            "escalation": new_escalation,
+        }
+    )
 
 
 class AnonymizingDataSource:
@@ -294,9 +337,7 @@ class AnonymizingDataSource:
         anonymized = self._engine.anonymize(data)
         return BytesIO(data_to_json_bytes(anonymized))
 
-    def watch(
-        self, callback: "Callable[[], Exception | None]"
-    ) -> Exception | None:
+    def watch(self, callback: "Callable[[], Exception | None]") -> Exception | None:
         """Delegate to the underlying data source."""
         result: Exception | None = self._source.watch(callback)
         return result

--- a/python/orgdatacore/_async.py
+++ b/python/orgdatacore/_async.py
@@ -29,9 +29,12 @@ from ._log import get_logger
 from ._service import parse_data
 from ._types import (
     Component,
+    ComponentOwnerInfo,
+    ComponentOwnership,
     Data,
     DataVersion,
     Employee,
+    EscalationContactInfo,
     GCSConfig,
     HierarchyNode,
     HierarchyPathEntry,
@@ -336,40 +339,58 @@ class AsyncService:
                 return self._data.lookups.employees.get(uid)
             return None
 
-    async def get_team_by_name(self, name: str) -> Team | None:
+    async def get_team_by_name(self, team_name: str) -> Team | None:
         """Get a team by name."""
         async with self._lock:
             if self._data is None:
                 return None
-            return self._data.lookups.teams.get(name)
+            return self._data.lookups.teams.get(team_name)
 
-    async def get_org_by_name(self, name: str) -> Org | None:
+    async def get_team_escalation(self, team_name: str) -> list[EscalationContactInfo]:
+        """Get the escalation contacts for a team.
+
+        Args:
+            team_name: The team name to look up.
+
+        Returns:
+            Ordered list of escalation contacts, or empty list if team
+            not found or has no escalation data.
+        """
+        async with self._lock:
+            if self._data is None or not self._data.lookups.teams:
+                return []
+            team = self._data.lookups.teams.get(team_name)
+            if team is None:
+                return []
+            return list(team.group.escalation)
+
+    async def get_org_by_name(self, org_name: str) -> Org | None:
         """Get an organization by name."""
         async with self._lock:
             if self._data is None:
                 return None
-            return self._data.lookups.orgs.get(name)
+            return self._data.lookups.orgs.get(org_name)
 
-    async def get_pillar_by_name(self, name: str) -> Pillar | None:
+    async def get_pillar_by_name(self, pillar_name: str) -> Pillar | None:
         """Get a pillar by name."""
         async with self._lock:
             if self._data is None:
                 return None
-            return self._data.lookups.pillars.get(name)
+            return self._data.lookups.pillars.get(pillar_name)
 
-    async def get_team_group_by_name(self, name: str) -> TeamGroup | None:
+    async def get_team_group_by_name(self, team_group_name: str) -> TeamGroup | None:
         """Get a team group by name."""
         async with self._lock:
             if self._data is None:
                 return None
-            return self._data.lookups.team_groups.get(name)
+            return self._data.lookups.team_groups.get(team_group_name)
 
-    async def get_component_by_name(self, name: str) -> Component | None:
+    async def get_component_by_name(self, component_name: str) -> Component | None:
         """Get a component by name."""
         async with self._lock:
             if self._data is None:
                 return None
-            return self._data.lookups.components.get(name)
+            return self._data.lookups.components.get(component_name)
 
     async def get_user_memberships(self, uid: str) -> list[MembershipInfo]:
         """Get all memberships for a user."""
@@ -579,10 +600,16 @@ class AsyncService:
 
             return build_node(entity_name, entity_type, set())
 
-    async def get_user_organizations(self, uid: str) -> list[OrgInfo]:
-        """Get organization info for a user."""
+    async def get_user_organizations(self, slack_user_id: str) -> list[OrgInfo]:
+        """Get the complete organizational hierarchy a Slack user belongs to."""
         async with self._lock:
-            if self._data is None:
+            if self._data is None or not self._data.indexes.membership.membership_index:
+                return []
+
+            uid = self._data.indexes.slack_id_mappings.slack_uid_to_uid.get(
+                slack_user_id, ""
+            )
+            if not uid:
                 return []
 
             memberships = self._data.indexes.membership.membership_index.get(uid, ())
@@ -660,6 +687,68 @@ class AsyncService:
             if self._data is None:
                 return []
             return list(self._data.lookups.components.values())
+
+    async def get_all_component_names(self) -> list[str]:
+        """Get all component names."""
+        async with self._lock:
+            if self._data is None:
+                return []
+            return list(self._data.lookups.components.keys())
+
+    async def get_teams_for_component(
+        self, component_name: str
+    ) -> list[ComponentOwnerInfo]:
+        """Get all teams/entities that own a component.
+
+        Args:
+            component_name: Component name to look up
+
+        Returns:
+            List of owner entities with ownership types.
+        """
+        async with self._lock:
+            if self._data is None:
+                return []
+            owners = self._data.indexes.component_ownership.component_owners.get(
+                component_name, ()
+            )
+            return list(owners)
+
+    async def get_components_for_team(self, team_name: str) -> list[ComponentOwnership]:
+        """Get all components owned by a team.
+
+        Uses the team's component_roles list for O(1) team lookup, then
+        resolves ownership types from the component_ownership index.
+
+        Args:
+            team_name: Team name to look up
+
+        Returns:
+            List of ComponentOwnership with component name and ownership types.
+        """
+        async with self._lock:
+            if self._data is None:
+                return []
+            team = self._data.lookups.teams.get(team_name)
+            if not team:
+                return []
+            result: list[ComponentOwnership] = []
+            for cr in team.group.component_roles:
+                ownership_types: tuple[str, ...] = ()
+                owners = self._data.indexes.component_ownership.component_owners.get(
+                    cr, ()
+                )
+                for owner in owners:
+                    if owner.name == team_name:
+                        ownership_types = owner.ownership_types
+                        break
+                result.append(
+                    ComponentOwnership(
+                        component=cr,
+                        ownership_types=ownership_types,
+                    )
+                )
+            return result
 
     async def get_all_team_names(self) -> list[str]:
         """Get all team names."""
@@ -863,180 +952,190 @@ async def _async_retry_with_backoff(
 
 
 try:
-    from google.cloud import storage  # type: ignore[import-untyped]
+    from google.cloud import storage
 
-    class AsyncGCSDataSource:
-        """Async GCS data source using google-cloud-storage.
+    _HAS_GCS = True
+except ImportError:
+    _HAS_GCS = False
 
-        Wraps sync GCS operations in asyncio.to_thread for non-blocking I/O.
 
-        Example:
-            config = GCSConfig(
-                bucket="my-bucket",
-                object_path="data.json",
-                project_id="my-project",
-            )
-            source = AsyncGCSDataSource(config)
-            service = AsyncService()
-            await service.load_from_data_source(source)
+class AsyncGCSDataSource:
+    """Async GCS data source using google-cloud-storage.
+
+    Wraps sync GCS operations in asyncio.to_thread for non-blocking I/O.
+
+    Requires the google-cloud-storage package:
+        pip install orgdatacore[gcs]
+
+    Example:
+        config = GCSConfig(
+            bucket="my-bucket",
+            object_path="data.json",
+            project_id="my-project",
+        )
+        source = AsyncGCSDataSource(config)
+        service = AsyncService()
+        await service.load_from_data_source(source)
+    """
+
+    def __init__(
+        self,
+        config: GCSConfig,
+        *,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        retry_delay: float = DEFAULT_RETRY_DELAY,
+        retry_backoff: float = DEFAULT_RETRY_BACKOFF,
+    ) -> None:
+        """Create an async GCS data source.
+
+        Args:
+            config: GCS configuration.
+            max_retries: Maximum retry attempts for transient failures.
+            retry_delay: Initial delay between retries in seconds.
+            retry_backoff: Multiplier for delay after each retry.
+
+        Raises:
+            ImportError: If google-cloud-storage is not installed.
+            ConfigurationError: If configuration is invalid.
         """
+        if not _HAS_GCS:
+            raise ImportError(
+                "google-cloud-storage is required for GCS support. "
+                "Install it with: pip install orgdatacore[gcs]"
+            )
+        if not config.bucket:
+            raise ConfigurationError("GCS bucket is required")
+        if not config.object_path:
+            raise ConfigurationError("GCS object_path is required")
 
-        def __init__(
-            self,
-            config: GCSConfig,
-            *,
-            max_retries: int = DEFAULT_MAX_RETRIES,
-            retry_delay: float = DEFAULT_RETRY_DELAY,
-            retry_backoff: float = DEFAULT_RETRY_BACKOFF,
-        ) -> None:
-            """Create an async GCS data source.
+        self.config = config
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self.retry_backoff = retry_backoff
+        self._client: Any = None
 
-            Args:
-                config: GCS configuration.
-                max_retries: Maximum retry attempts for transient failures.
-                retry_delay: Initial delay between retries in seconds.
-                retry_backoff: Multiplier for delay after each retry.
-
-            Raises:
-                ConfigurationError: If configuration is invalid.
-            """
-            if not config.bucket:
-                raise ConfigurationError("GCS bucket is required")
-            if not config.object_path:
-                raise ConfigurationError("GCS object_path is required")
-
-            self.config = config
-            self.max_retries = max_retries
-            self.retry_delay = retry_delay
-            self.retry_backoff = retry_backoff
-            self._client: storage.Client | None = None
-
-        def _get_client(self) -> storage.Client:
-            """Get or create the GCS client (sync)."""
-            if self._client is None:
-                logger = get_logger()
-                logger.debug(
-                    "Creating GCS client", extra={"project_id": self.config.project_id}
-                )
-
-                if self.config.credentials_json:
-                    self._client = storage.Client.from_service_account_json(
-                        self.config.credentials_json
-                    )
-                else:
-                    self._client = storage.Client(
-                        project=self.config.project_id or None
-                    )
-            return self._client
-
-        async def load(self) -> BinaryIO:
-            """Load data from GCS asynchronously.
-
-            Returns:
-                File-like object containing the JSON data.
-
-            Raises:
-                GCSError: If loading fails after all retries.
-            """
+    def _get_client(self) -> Any:
+        """Get or create the GCS client (sync)."""
+        if self._client is None:
             logger = get_logger()
             logger.debug(
-                "Loading from GCS (async)",
-                extra={"bucket": self.config.bucket, "object": self.config.object_path},
+                "Creating GCS client", extra={"project_id": self.config.project_id}
             )
 
-            async def _download() -> BinaryIO:
-                def _sync_download() -> BinaryIO:
-                    client = self._get_client()
-                    bucket = client.bucket(self.config.bucket)
-                    blob = bucket.blob(self.config.object_path)
-                    return BytesIO(blob.download_as_bytes())
+            if self.config.credentials_json:
+                import json as _json
 
-                return await asyncio.to_thread(_sync_download)
+                creds_info = _json.loads(self.config.credentials_json)
+                self._client = storage.Client.from_service_account_info(creds_info)
+            else:
+                self._client = storage.Client(project=self.config.project_id or None)
+        return self._client
 
-            return await _async_retry_with_backoff(
-                _download,
-                max_retries=self.max_retries,
-                initial_delay=self.retry_delay,
-                backoff=self.retry_backoff,
-                operation_name=f"GCS download gs://{self.config.bucket}/{self.config.object_path}",
-            )
+    async def load(self) -> BinaryIO:
+        """Load data from GCS asynchronously.
 
-        async def watch(
-            self, callback: Callable[[], Awaitable[Exception | None]]
-        ) -> Exception | None:
-            """Monitor for changes and call async callback when data is updated.
+        Returns:
+            File-like object containing the JSON data.
 
-            Args:
-                callback: Async function to call when data changes.
+        Raises:
+            GCSError: If loading fails after all retries.
+        """
+        logger = get_logger()
+        logger.debug(
+            "Loading from GCS (async)",
+            extra={"bucket": self.config.bucket, "object": self.config.object_path},
+        )
 
-            Returns:
-                Exception if watcher setup fails, None otherwise.
-            """
-            logger = get_logger()
-
-            try:
+        async def _download() -> BinaryIO:
+            def _sync_download() -> BinaryIO:
                 client = self._get_client()
                 bucket = client.bucket(self.config.bucket)
                 blob = bucket.blob(self.config.object_path)
+                return BytesIO(blob.download_as_bytes())
 
-                # Get initial generation (sync, but quick)
-                await asyncio.to_thread(blob.reload)
-                last_generation = blob.generation
+            return await asyncio.to_thread(_sync_download)
 
-                logger.info(
-                    "Starting async GCS watcher",
-                    extra={
-                        "bucket": self.config.bucket,
-                        "object": self.config.object_path,
-                        "check_interval": str(self.config.check_interval),
-                    },
-                )
-            except Exception as e:
-                logger.error(
-                    "Failed to initialize async GCS watcher", extra={"error": str(e)}
-                )
-                return GCSError(f"Failed to initialize GCS watcher: {e}")
+        return await _async_retry_with_backoff(
+            _download,
+            max_retries=self.max_retries,
+            initial_delay=self.retry_delay,
+            backoff=self.retry_backoff,
+            operation_name=f"GCS download gs://{self.config.bucket}/{self.config.object_path}",
+        )
 
-            async def watcher() -> None:
-                nonlocal last_generation
-                interval = self.config.check_interval.total_seconds()
+    async def watch(
+        self, callback: Callable[[], Awaitable[Exception | None]]
+    ) -> Exception | None:
+        """Monitor for changes and call async callback when data is updated.
 
-                while True:
-                    await asyncio.sleep(interval)
+        This coroutine blocks until cancelled. The caller should wrap it in
+        asyncio.create_task() and cancel the task to stop watching.
 
-                    try:
-                        await asyncio.to_thread(blob.reload)
-                        if blob.generation != last_generation:
-                            logger.info(
-                                "GCS object changed, triggering async reload",
-                                extra={
-                                    "old_generation": last_generation,
-                                    "new_generation": blob.generation,
-                                },
-                            )
-                            last_generation = blob.generation
-                            err = await callback()
-                            if err:
-                                logger.error(
-                                    "Async reload callback failed",
-                                    extra={"error": str(err)},
-                                )
-                    except asyncio.CancelledError:
-                        logger.info("Async GCS watcher cancelled")
-                        break
-                    except Exception as e:
-                        logger.error(
-                            "Async GCS watcher check failed", extra={"error": str(e)}
+        Args:
+            callback: Async function to call when data changes.
+
+        Returns:
+            Exception if watcher setup fails, None otherwise.
+        """
+        logger = get_logger()
+
+        try:
+            client = self._get_client()
+            bucket = client.bucket(self.config.bucket)
+            blob = bucket.blob(self.config.object_path)
+
+            # Get initial generation (sync, but quick)
+            await asyncio.to_thread(blob.reload)
+            last_generation = blob.generation
+
+            logger.info(
+                "Starting async GCS watcher",
+                extra={
+                    "bucket": self.config.bucket,
+                    "object": self.config.object_path,
+                    "check_interval": str(self.config.check_interval),
+                },
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to initialize async GCS watcher", extra={"error": str(e)}
+            )
+            return GCSError(f"Failed to initialize GCS watcher: {e}")
+
+        interval = self.config.check_interval.total_seconds()
+
+        try:
+            while True:
+                await asyncio.sleep(interval)
+
+                try:
+                    await asyncio.to_thread(blob.reload)
+                    if blob.generation != last_generation:
+                        logger.info(
+                            "GCS object changed, triggering async reload",
+                            extra={
+                                "old_generation": last_generation,
+                                "new_generation": blob.generation,
+                            },
                         )
+                        last_generation = blob.generation
+                        err = await callback()
+                        if err:
+                            logger.error(
+                                "Async reload callback failed",
+                                extra={"error": str(err)},
+                            )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.error(
+                        "Async GCS watcher check failed", extra={"error": str(e)}
+                    )
+        except asyncio.CancelledError:
+            logger.info("Async GCS watcher cancelled")
 
-            # Start watcher as background task
-            asyncio.create_task(watcher())
-            return None
+        return None
 
-        def __str__(self) -> str:
-            """Return a description of this data source."""
-            return f"gs://{self.config.bucket}/{self.config.object_path} (async)"
-
-except ImportError:
-    # google-cloud-storage not available
-    pass
+    def __str__(self) -> str:
+        """Return a description of this data source."""
+        return f"gs://{self.config.bucket}/{self.config.object_path} (async)"

--- a/python/orgdatacore/_gcs.py
+++ b/python/orgdatacore/_gcs.py
@@ -39,7 +39,7 @@ import threading
 import time
 from collections.abc import Callable
 from io import BytesIO
-from typing import BinaryIO, TypeVar
+from typing import Any, BinaryIO, TypeVar
 
 from ._exceptions import ConfigurationError, GCSError
 from ._log import get_logger
@@ -53,63 +53,12 @@ DEFAULT_RETRY_DELAY = 1.0  # seconds
 DEFAULT_RETRY_BACKOFF = 2.0  # multiplier
 
 
-class GCSDataSource:
-    """
-    GCSDataSource is a stub for GCS support.
+try:
+    from google.cloud import storage
 
-    To enable actual GCS support, install the google-cloud-storage package
-    and use GCSDataSourceWithSDK instead.
-
-    For custom data sources, implement the DataSource protocol:
-
-        class MyCustomDataSource:
-            def load(self) -> BinaryIO: ...
-            def watch(self, callback) -> Optional[Exception]: ...
-            def __str__(self) -> str: ...
-    """
-
-    def __init__(self, config: GCSConfig) -> None:
-        """
-        Create a stub GCS data source.
-
-        For production use with actual GCS functionality, install google-cloud-storage
-        and use GCSDataSourceWithSDK instead.
-
-        Args:
-            config: GCS configuration with bucket, object path, etc.
-        """
-        self.config = config
-
-    def load(self) -> BinaryIO:
-        """
-        Returns an error indicating GCS support is not enabled.
-
-        Raises:
-            GCSError: Always, as this is a stub implementation.
-        """
-        raise GCSError(
-            "GCS support not enabled: install google-cloud-storage and use "
-            "GCSDataSourceWithSDK(), or implement a custom DataSource."
-        )
-
-    def watch(self, callback: Callable[[], Exception | None]) -> Exception | None:
-        """
-        Returns an error indicating GCS support is not enabled.
-
-        Returns:
-            GCSError: Always, as this is a stub implementation.
-        """
-        return GCSError(
-            "GCS support not enabled: install google-cloud-storage and use "
-            "GCSDataSourceWithSDK()"
-        )
-
-    def __str__(self) -> str:
-        """Return a description of this data source."""
-        return (
-            f"gs://{self.config.bucket}/{self.config.object_path} "
-            "(stub - install google-cloud-storage for actual support)"
-        )
+    _HAS_GCS = True
+except ImportError:
+    _HAS_GCS = False
 
 
 def _retry_with_backoff(
@@ -169,206 +118,200 @@ def _retry_with_backoff(
     )
 
 
-try:
-    from google.cloud import storage  # type: ignore[import-untyped]
+class GCSDataSource:
+    """GCS data source using google-cloud-storage.
 
-    class GCSDataSourceWithSDK:
+    Requires the google-cloud-storage package:
+        pip install orgdatacore[gcs]
+
+    Features:
+    - Automatic retry with exponential backoff for transient failures
+    - Structured logging for observability
+    - Proper error handling with custom exceptions
+
+    Example:
+        from orgdatacore import GCSConfig, GCSDataSource
+        from datetime import timedelta
+
+        config = GCSConfig(
+            bucket="your-bucket",
+            object_path="path/to/data.json",
+            project_id="your-project",
+            check_interval=timedelta(minutes=5),
+        )
+        source = GCSDataSource(config)
+        service.load_from_data_source(source)
+    """
+
+    def __init__(
+        self,
+        config: GCSConfig,
+        *,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        retry_delay: float = DEFAULT_RETRY_DELAY,
+        retry_backoff: float = DEFAULT_RETRY_BACKOFF,
+    ) -> None:
+        """Create a GCS data source.
+
+        Args:
+            config: GCS configuration.
+            max_retries: Maximum retry attempts for transient failures.
+            retry_delay: Initial delay between retries in seconds.
+            retry_backoff: Multiplier for delay after each retry.
+
+        Raises:
+            ImportError: If google-cloud-storage is not installed.
+            ConfigurationError: If configuration is invalid.
         """
-        GCSDataSourceWithSDK provides actual GCS support using the Google Cloud SDK.
-
-        Requires the google-cloud-storage package to be installed:
-            pip install google-cloud-storage
-
-        Features:
-        - Automatic retry with exponential backoff for transient failures
-        - Structured logging for observability
-        - Proper error handling with custom exceptions
-
-        Example:
-            from orgdatacore import GCSConfig
-            from orgdatacore.datasources import GCSDataSourceWithSDK
-            from datetime import timedelta
-
-            config = GCSConfig(
-                bucket="your-bucket",
-                object_path="path/to/data.json",
-                project_id="your-project",
-                check_interval=timedelta(minutes=5),
+        if not _HAS_GCS:
+            raise ImportError(
+                "google-cloud-storage is required for GCS support. "
+                "Install it with: pip install orgdatacore[gcs]"
             )
-            source = GCSDataSourceWithSDK(config)
-            service.load_from_data_source(source)
-        """
+        if not config.bucket:
+            raise ConfigurationError("GCS bucket is required")
+        if not config.object_path:
+            raise ConfigurationError("GCS object_path is required")
 
-        def __init__(
-            self,
-            config: GCSConfig,
-            *,
-            max_retries: int = DEFAULT_MAX_RETRIES,
-            retry_delay: float = DEFAULT_RETRY_DELAY,
-            retry_backoff: float = DEFAULT_RETRY_BACKOFF,
-        ) -> None:
-            """Create a GCS data source with SDK support.
+        self.config = config
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self.retry_backoff = retry_backoff
+        self._client: Any = None
+        self._stop_event = threading.Event()
 
-            Args:
-                config: GCS configuration.
-                max_retries: Maximum retry attempts for transient failures.
-                retry_delay: Initial delay between retries in seconds.
-                retry_backoff: Multiplier for delay after each retry.
-
-            Raises:
-                ConfigurationError: If configuration is invalid.
-            """
-            if not config.bucket:
-                raise ConfigurationError("GCS bucket is required")
-            if not config.object_path:
-                raise ConfigurationError("GCS object_path is required")
-
-            self.config = config
-            self.max_retries = max_retries
-            self.retry_delay = retry_delay
-            self.retry_backoff = retry_backoff
-            self._client: storage.Client | None = None
-            self._stop_event = threading.Event()
-
-        def _get_client(self) -> storage.Client:
-            """Get or create the GCS client."""
-            if self._client is None:
-                logger = get_logger()
-                logger.debug(
-                    "Creating GCS client", extra={"project_id": self.config.project_id}
-                )
-
-                if self.config.credentials_json:
-                    self._client = storage.Client.from_service_account_json(
-                        self.config.credentials_json
-                    )
-                else:
-                    self._client = storage.Client(
-                        project=self.config.project_id or None
-                    )
-            return self._client
-
-        def load(self) -> BinaryIO:
-            """Load and return a reader for the organizational data from GCS.
-
-            Returns:
-                File-like object containing the JSON data.
-
-            Raises:
-                GCSError: If loading fails after all retries.
-            """
+    def _get_client(self) -> Any:
+        """Get or create the GCS client."""
+        if self._client is None:
             logger = get_logger()
             logger.debug(
-                "Loading from GCS",
-                extra={"bucket": self.config.bucket, "object": self.config.object_path},
+                "Creating GCS client", extra={"project_id": self.config.project_id}
             )
 
-            def _download() -> BinaryIO:
-                client = self._get_client()
-                bucket = client.bucket(self.config.bucket)
-                blob = bucket.blob(self.config.object_path)
-                content = blob.download_as_bytes()
-                return BytesIO(content)
+            if self.config.credentials_json:
+                import json as _json
 
-            return _retry_with_backoff(
-                _download,
-                max_retries=self.max_retries,
-                initial_delay=self.retry_delay,
-                backoff=self.retry_backoff,
-                operation_name=f"GCS download gs://{self.config.bucket}/{self.config.object_path}",
+                creds_info = _json.loads(self.config.credentials_json)
+                self._client = storage.Client.from_service_account_info(creds_info)
+            else:
+                self._client = storage.Client(project=self.config.project_id or None)
+        return self._client
+
+    def load(self) -> BinaryIO:
+        """Load and return a reader for the organizational data from GCS.
+
+        Returns:
+            File-like object containing the JSON data.
+
+        Raises:
+            GCSError: If loading fails after all retries.
+        """
+        logger = get_logger()
+        logger.debug(
+            "Loading from GCS",
+            extra={"bucket": self.config.bucket, "object": self.config.object_path},
+        )
+
+        def _download() -> BinaryIO:
+            client = self._get_client()
+            bucket = client.bucket(self.config.bucket)
+            blob = bucket.blob(self.config.object_path)
+            content = blob.download_as_bytes()
+            return BytesIO(content)
+
+        return _retry_with_backoff(
+            _download,
+            max_retries=self.max_retries,
+            initial_delay=self.retry_delay,
+            backoff=self.retry_backoff,
+            operation_name=f"GCS download gs://{self.config.bucket}/{self.config.object_path}",
+        )
+
+    def watch(self, callback: Callable[[], Exception | None]) -> Exception | None:
+        """Monitor for changes and call callback when data is updated.
+
+        Uses polling based on the configured check interval.
+        Detects changes by comparing object generation numbers.
+
+        Args:
+            callback: Function to call when data changes.
+
+        Returns:
+            Exception if watcher setup fails, None otherwise.
+        """
+        logger = get_logger()
+
+        # Reset stop event so watch() can be called again after stop_watching()
+        self._stop_event = threading.Event()
+
+        try:
+            client = self._get_client()
+            bucket = client.bucket(self.config.bucket)
+            blob = bucket.blob(self.config.object_path)
+
+            # Get initial generation
+            blob.reload()
+            last_generation = blob.generation
+
+            logger.info(
+                "Starting GCS watcher",
+                extra={
+                    "bucket": self.config.bucket,
+                    "object": self.config.object_path,
+                    "check_interval": str(self.config.check_interval),
+                    "initial_generation": last_generation,
+                },
             )
+        except Exception as e:
+            logger.error("Failed to initialize GCS watcher", extra={"error": str(e)})
+            return GCSError(f"Failed to initialize GCS watcher: {e}")
 
-        def watch(self, callback: Callable[[], Exception | None]) -> Exception | None:
-            """
-            Monitor for changes and call callback when data is updated.
+        def watcher() -> None:
+            nonlocal last_generation
+            interval = self.config.check_interval.total_seconds()
 
-            Uses polling based on the configured check interval.
-            Detects changes by comparing object generation numbers.
+            while not self._stop_event.is_set():
+                time.sleep(interval)
+                if self._stop_event.is_set():
+                    break
 
-            Args:
-                callback: Function to call when data changes.
-
-            Returns:
-                Exception if watcher setup fails, None otherwise.
-            """
-            logger = get_logger()
-
-            try:
-                client = self._get_client()
-                bucket = client.bucket(self.config.bucket)
-                blob = bucket.blob(self.config.object_path)
-
-                # Get initial generation
-                blob.reload()
-                last_generation = blob.generation
-
-                logger.info(
-                    "Starting GCS watcher",
-                    extra={
-                        "bucket": self.config.bucket,
-                        "object": self.config.object_path,
-                        "check_interval": str(self.config.check_interval),
-                        "initial_generation": last_generation,
-                    },
-                )
-            except Exception as e:
-                logger.error(
-                    "Failed to initialize GCS watcher", extra={"error": str(e)}
-                )
-                return GCSError(f"Failed to initialize GCS watcher: {e}")
-
-            def watcher() -> None:
-                nonlocal last_generation
-                interval = self.config.check_interval.total_seconds()
-
-                while not self._stop_event.is_set():
-                    time.sleep(interval)
-                    if self._stop_event.is_set():
-                        break
-
-                    try:
-                        blob.reload()
-                        if blob.generation != last_generation:
-                            logger.info(
-                                "GCS object changed, triggering reload",
-                                extra={
-                                    "old_generation": last_generation,
-                                    "new_generation": blob.generation,
-                                },
-                            )
-                            last_generation = blob.generation
-                            err = callback()
-                            if err:
-                                logger.error(
-                                    "Reload callback failed", extra={"error": str(err)}
-                                )
-                    except Exception as e:
-                        logger.error(
-                            "GCS watcher check failed", extra={"error": str(e)}
+                try:
+                    blob.reload()
+                    if blob.generation != last_generation:
+                        logger.info(
+                            "GCS object changed, triggering reload",
+                            extra={
+                                "old_generation": last_generation,
+                                "new_generation": blob.generation,
+                            },
                         )
+                        last_generation = blob.generation
+                        err = callback()
+                        if err:
+                            logger.error(
+                                "Reload callback failed", extra={"error": str(err)}
+                            )
+                except Exception as e:
+                    logger.error("GCS watcher check failed", extra={"error": str(e)})
 
-            thread = threading.Thread(target=watcher, daemon=True, name="gcs-watcher")
-            thread.start()
-            return None
+        thread = threading.Thread(target=watcher, daemon=True, name="gcs-watcher")
+        thread.start()
+        return None
 
-        def stop_watching(self) -> None:
-            """Stop the GCS watcher."""
-            logger = get_logger()
-            logger.info("Stopping GCS watcher")
-            self._stop_event.set()
+    def stop_watching(self) -> None:
+        """Stop the GCS watcher."""
+        logger = get_logger()
+        logger.info("Stopping GCS watcher")
+        self._stop_event.set()
 
-        def stop(self) -> None:
-            """Stop the GCS watcher.
+    def stop(self) -> None:
+        """Stop the GCS watcher.
 
-            Alias for stop_watching() to support the standard stop interface
-            expected by AsyncService.stop_watcher().
-            """
-            self.stop_watching()
+        Alias for stop_watching() to support the standard stop interface
+        expected by AsyncService.stop_watcher().
+        """
+        self.stop_watching()
 
-        def __str__(self) -> str:
-            """Return a description of this data source."""
-            return f"gs://{self.config.bucket}/{self.config.object_path}"
-
-except ImportError:
-    # google-cloud-storage not available
-    pass
+    def __str__(self) -> str:
+        """Return a description of this data source."""
+        return f"gs://{self.config.bucket}/{self.config.object_path}"

--- a/python/orgdatacore/_redaction.py
+++ b/python/orgdatacore/_redaction.py
@@ -1,9 +1,8 @@
-"""Data source wrapper for PII redaction."""
+"""Data source wrappers for PII redaction."""
 
 import json
-from dataclasses import replace
 from io import BytesIO
-from typing import TYPE_CHECKING, BinaryIO
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 from ._serialization import data_to_json_bytes
 from ._service import parse_data
@@ -11,6 +10,7 @@ from ._types import (
     Data,
     DataSource,
     GitHubIDMappings,
+    Group,
     PIIMode,
     SlackIDMappings,
 )
@@ -50,6 +50,10 @@ class RedactingDataSource:
             source: The underlying data source to wrap.
             pii_mode: The PII handling mode. Defaults to FULL (no redaction).
         """
+        if pii_mode not in (PIIMode.FULL, PIIMode.REDACTED):
+            raise ValueError(
+                f"RedactingDataSource only supports FULL and REDACTED modes, got {pii_mode!r}"
+            )
         self._source = source
         self._pii_mode = pii_mode
 
@@ -74,9 +78,7 @@ class RedactingDataSource:
         redacted = _redact(data)
         return BytesIO(data_to_json_bytes(redacted))
 
-    def watch(
-        self, callback: "Callable[[], Exception | None]"
-    ) -> Exception | None:
+    def watch(self, callback: "Callable[[], Exception | None]") -> Exception | None:
         """
         Monitor for changes and call the callback when data is updated.
 
@@ -96,24 +98,111 @@ class RedactingDataSource:
         return f"{self._source}{mode_suffix}"
 
 
+class AsyncRedactingDataSource:
+    """Async DataSource decorator that redacts PII from loaded data.
+
+    Same redaction as RedactingDataSource but with async load().
+    Use with AsyncService and async inner sources.
+    """
+
+    def __init__(
+        self,
+        source: Any,
+        pii_mode: PIIMode = PIIMode.FULL,
+    ) -> None:
+        if pii_mode not in (PIIMode.FULL, PIIMode.REDACTED):
+            raise ValueError(
+                f"AsyncRedactingDataSource only supports FULL and REDACTED modes, got {pii_mode!r}"
+            )
+        self._source = source
+        self._pii_mode = pii_mode
+
+    async def load(self) -> BinaryIO:
+        """Load data asynchronously, optionally redacting PII fields."""
+        reader: BinaryIO = await self._source.load()
+
+        if self._pii_mode == PIIMode.FULL:
+            return reader
+
+        try:
+            raw = reader.read()
+        finally:
+            reader.close()
+        text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+        raw_data = json.loads(text)
+        data = parse_data(raw_data)
+        redacted = _redact(data)
+        return BytesIO(data_to_json_bytes(redacted))
+
+    async def watch(self, callback: Any) -> Any:
+        """Delegate to the underlying data source."""
+        return await self._source.watch(callback)
+
+    def __str__(self) -> str:
+        mode_suffix = " [PII redacted]" if self._pii_mode == PIIMode.REDACTED else ""
+        return f"{self._source}{mode_suffix}"
+
+
 def _redact(data: Data) -> Data:
     """Return a new Data with PII fields redacted."""
     new_employees = {
-        uid: replace(
-            emp,
-            full_name="[REDACTED]",
-            email="[REDACTED]",
-            slack_uid="",
-            github_id="",
+        uid: emp.model_copy(
+            update={
+                "full_name": "[REDACTED]",
+                "email": "[REDACTED]",
+                "slack_uid": "",
+                "github_id": "",
+            }
         )
         for uid, emp in data.lookups.employees.items()
     }
-    return replace(
-        data,
-        lookups=replace(data.lookups, employees=new_employees),
-        indexes=replace(
-            data.indexes,
-            slack_id_mappings=SlackIDMappings(slack_uid_to_uid={}),
-            github_id_mappings=GitHubIDMappings(github_id_to_uid={}),
-        ),
+
+    new_teams = {
+        name: team.model_copy(update={"group": _redact_group(team.group)})
+        for name, team in data.lookups.teams.items()
+    }
+    new_orgs = {
+        name: org.model_copy(update={"group": _redact_group(org.group)})
+        for name, org in data.lookups.orgs.items()
+    }
+    new_pillars = {
+        name: pillar.model_copy(update={"group": _redact_group(pillar.group)})
+        for name, pillar in data.lookups.pillars.items()
+    }
+    new_team_groups = {
+        name: tg.model_copy(update={"group": _redact_group(tg.group)})
+        for name, tg in data.lookups.team_groups.items()
+    }
+
+    return data.model_copy(
+        update={
+            "lookups": data.lookups.model_copy(
+                update={
+                    "employees": new_employees,
+                    "teams": new_teams,
+                    "orgs": new_orgs,
+                    "pillars": new_pillars,
+                    "team_groups": new_team_groups,
+                }
+            ),
+            "indexes": data.indexes.model_copy(
+                update={
+                    "slack_id_mappings": SlackIDMappings(slack_uid_to_uid={}),
+                    "github_id_mappings": GitHubIDMappings(github_id_to_uid={}),
+                }
+            ),
+        }
     )
+
+
+def _redact_group(group: Group) -> Group:
+    """Return a new Group with escalation contacts redacted."""
+    if not group.escalation:
+        return group
+    new_escalation = tuple(
+        contact.model_copy(
+            update={"name": "[REDACTED]", "url": "", "description": "[REDACTED]"}
+        )
+        for contact in group.escalation
+    )
+    return group.model_copy(update={"escalation": new_escalation})

--- a/python/orgdatacore/_serialization.py
+++ b/python/orgdatacore/_serialization.py
@@ -1,4 +1,4 @@
-"""Internal serialization: Data dataclass → dict/JSON bytes.
+"""Internal serialization: Data model -> dict/JSON bytes.
 
 Not part of the public API. Used by PII decorators and test helpers
 to round-trip typed Data through JSON without raw dict manipulation.
@@ -22,25 +22,16 @@ from ._types import (
 def data_to_dict(data: Data) -> dict[str, Any]:
     """Convert Data to dictionary for JSON serialization."""
     result: dict[str, Any] = {
-        "metadata": {
-            "generated_at": data.metadata.generated_at,
-            "data_version": data.metadata.data_version,
-            "total_employees": data.metadata.total_employees,
-            "total_orgs": data.metadata.total_orgs,
-            "total_teams": data.metadata.total_teams,
-        },
+        "metadata": data.metadata.model_dump(),
         "lookups": {
             "employees": {
                 k: employee_to_dict(v) for k, v in data.lookups.employees.items()
             },
-            "teams": {k: team_to_dict(v) for k, v in data.lookups.teams.items()},
-            "orgs": {k: org_to_dict(v) for k, v in data.lookups.orgs.items()},
-            "pillars": {
-                k: pillar_to_dict(v) for k, v in data.lookups.pillars.items()
-            },
+            "teams": {k: entity_to_dict(v) for k, v in data.lookups.teams.items()},
+            "orgs": {k: entity_to_dict(v) for k, v in data.lookups.orgs.items()},
+            "pillars": {k: entity_to_dict(v) for k, v in data.lookups.pillars.items()},
             "team_groups": {
-                k: team_group_to_dict(v)
-                for k, v in data.lookups.team_groups.items()
+                k: entity_to_dict(v) for k, v in data.lookups.team_groups.items()
             },
             "components": {
                 k: component_to_dict(v) for k, v in data.lookups.components.items()
@@ -49,7 +40,7 @@ def data_to_dict(data: Data) -> dict[str, Any]:
         "indexes": {
             "membership": {
                 "membership_index": {
-                    k: [{"name": m.name, "type": m.type} for m in v]
+                    k: [m.model_dump() for m in v]
                     for k, v in data.indexes.membership.membership_index.items()
                 },
             },
@@ -69,10 +60,15 @@ def data_to_dict(data: Data) -> dict[str, Any]:
     if data.indexes.jira.project_component_owners:
         result["indexes"]["jira"] = {
             project: {
-                component: [{"name": o.name, "type": o.type} for o in owners]
+                component: [o.model_dump() for o in owners]
                 for component, owners in components.items()
             }
             for project, components in data.indexes.jira.project_component_owners.items()
+        }
+    if data.indexes.component_ownership.component_owners:
+        result["indexes"]["component_ownership"] = {
+            component_name: [o.model_dump() for o in owners]
+            for component_name, owners in data.indexes.component_ownership.component_owners.items()
         }
     return result
 
@@ -94,42 +90,22 @@ def component_to_dict(component: Component) -> dict[str, Any]:
     if component.type:
         nested["type"] = {"name": component.type}
     if component.repos:
-        nested["repos"] = [
-            {
-                "repo_name": r.repo,
-                "description": r.description,
-                "tags": list(r.tags),
-                "path": r.path,
-                "roles": list(r.roles),
-                "branch": r.branch,
-                "types": list(r.types),
-            }
-            for r in component.repos
-        ]
+        nested["repos"] = [r.model_dump(by_alias=True) for r in component.repos]
     if component.jiras:
-        nested["jiras"] = [
-            {
-                "project": j.project,
-                "component": j.component,
-                "description": j.description,
-                "view": j.view,
-                "types": list(j.types),
-            }
-            for j in component.jiras
-        ]
+        nested["jiras"] = [j.model_dump() for j in component.jiras]
     if component.repos_list:
         nested["repos_list"] = list(component.repos_list)
     if nested:
         d["component"] = nested
     if component.parent:
-        d["parent"] = {"name": component.parent.name, "type": component.parent.type}
+        d["parent"] = component.parent.model_dump()
     if component.parent_path:
         d["parent_path"] = component.parent_path
     return d
 
 
 def employee_to_dict(emp: Employee) -> dict[str, Any]:
-    """Convert Employee to dictionary."""
+    """Convert Employee to dictionary with conditional includes."""
     d: dict[str, Any] = {
         "uid": emp.uid,
         "full_name": emp.full_name,
@@ -153,142 +129,44 @@ def employee_to_dict(emp: Employee) -> dict[str, Any]:
 
 
 def group_to_dict(group: Group) -> dict[str, Any]:
-    """Convert Group to dictionary."""
+    """Convert Group to dictionary with conditional includes."""
     d: dict[str, Any] = {
-        "type": {"name": group.type.name},
+        "type": group.type.model_dump(),
         "resolved_people_uid_list": list(group.resolved_people_uid_list),
     }
     if group.slack:
-        d["slack"] = {
-            "channels": [
-                {
-                    "channel": c.channel,
-                    "channel_id": c.channel_id,
-                    "description": c.description,
-                    "types": list(c.types),
-                }
-                for c in group.slack.channels
-            ],
-            "aliases": [
-                {"alias": a.alias, "description": a.description}
-                for a in group.slack.aliases
-            ],
-        }
+        d["slack"] = group.slack.model_dump()
     if group.roles:
-        roles_list = []
-        for r in group.roles:
-            role_d: dict[str, Any] = {"people": list(r.people), "roles": list(r.roles)}
-            if r.description:
-                role_d["description"] = r.description
-            roles_list.append(role_d)
-        d["resolved_roles"] = roles_list
+        d["resolved_roles"] = [r.model_dump() for r in group.roles]
     if group.jiras:
-        d["jiras"] = [
-            {
-                "project": j.project,
-                "component": j.component,
-                "description": j.description,
-                "view": j.view,
-                "types": list(j.types),
-            }
-            for j in group.jiras
-        ]
+        d["jiras"] = [j.model_dump() for j in group.jiras]
     if group.repos:
-        d["repos"] = [
-            {
-                "repo_name": r.repo,
-                "description": r.description,
-                "tags": list(r.tags),
-                "path": r.path,
-                "roles": list(r.roles),
-                "branch": r.branch,
-                "types": list(r.types),
-            }
-            for r in group.repos
-        ]
+        d["repos"] = [r.model_dump(by_alias=True) for r in group.repos]
     if group.keywords:
         d["keywords"] = list(group.keywords)
     if group.emails:
-        d["emails"] = [
-            {"address": e.address, "name": e.name, "description": e.description}
-            for e in group.emails
-        ]
+        d["emails"] = [e.model_dump() for e in group.emails]
     if group.resources:
-        d["resources"] = [
-            {"name": r.name, "url": r.url, "description": r.description}
-            for r in group.resources
-        ]
+        d["resources"] = [r.model_dump() for r in group.resources]
+    if group.escalation:
+        d["escalation"] = [e.model_dump() for e in group.escalation]
     if group.component_roles:
-        d["component_roles"] = [
-            {"component": c.component, "types": list(c.types)}
-            for c in group.component_roles
-        ]
+        d["component_roles"] = list(group.component_roles)
     return d
 
 
-def team_to_dict(team: Team) -> dict[str, Any]:
-    """Convert Team to dictionary."""
+def entity_to_dict(entity: Team | Org | Pillar | TeamGroup) -> dict[str, Any]:
+    """Convert a Team/Org/Pillar/TeamGroup to dictionary."""
     d: dict[str, Any] = {
-        "uid": team.uid,
-        "name": team.name,
-        "type": team.type,
-        "group": group_to_dict(team.group),
+        "uid": entity.uid,
+        "name": entity.name,
+        "type": entity.type,
+        "group": group_to_dict(entity.group),
     }
-    if team.tab_name:
-        d["tab_name"] = team.tab_name
-    if team.description:
-        d["description"] = team.description
-    if team.parent:
-        d["parent"] = {"name": team.parent.name, "type": team.parent.type}
-    return d
-
-
-def org_to_dict(org: Org) -> dict[str, Any]:
-    """Convert Org to dictionary."""
-    d: dict[str, Any] = {
-        "uid": org.uid,
-        "name": org.name,
-        "type": org.type,
-        "group": group_to_dict(org.group),
-    }
-    if org.tab_name:
-        d["tab_name"] = org.tab_name
-    if org.description:
-        d["description"] = org.description
-    if org.parent:
-        d["parent"] = {"name": org.parent.name, "type": org.parent.type}
-    return d
-
-
-def pillar_to_dict(pillar: Pillar) -> dict[str, Any]:
-    """Convert Pillar to dictionary."""
-    d: dict[str, Any] = {
-        "uid": pillar.uid,
-        "name": pillar.name,
-        "type": pillar.type,
-        "group": group_to_dict(pillar.group),
-    }
-    if pillar.tab_name:
-        d["tab_name"] = pillar.tab_name
-    if pillar.description:
-        d["description"] = pillar.description
-    if pillar.parent:
-        d["parent"] = {"name": pillar.parent.name, "type": pillar.parent.type}
-    return d
-
-
-def team_group_to_dict(team_group: TeamGroup) -> dict[str, Any]:
-    """Convert TeamGroup to dictionary."""
-    d: dict[str, Any] = {
-        "uid": team_group.uid,
-        "name": team_group.name,
-        "type": team_group.type,
-        "group": group_to_dict(team_group.group),
-    }
-    if team_group.tab_name:
-        d["tab_name"] = team_group.tab_name
-    if team_group.description:
-        d["description"] = team_group.description
-    if team_group.parent:
-        d["parent"] = {"name": team_group.parent.name, "type": team_group.parent.type}
+    if entity.tab_name:
+        d["tab_name"] = entity.tab_name
+    if entity.description:
+        d["description"] = entity.description
+    if entity.parent:
+        d["parent"] = entity.parent.model_dump()
     return d

--- a/python/orgdatacore/_service.py
+++ b/python/orgdatacore/_service.py
@@ -8,23 +8,20 @@ from typing import Any, cast
 from ._exceptions import DataLoadError
 from ._log import get_logger
 from ._types import (
-    AliasInfo,
-    ChannelInfo,
     Component,
-    ComponentRoleInfo,
+    ComponentOwnerInfo,
+    ComponentOwnership,
+    ComponentOwnershipIndex,
     Data,
     DataSource,
     DataVersion,
-    EmailInfo,
     Employee,
+    EscalationContactInfo,
     GitHubIDMappings,
-    Group,
-    GroupType,
     HierarchyNode,
     HierarchyPathEntry,
     Indexes,
     JiraIndex,
-    JiraInfo,
     JiraOwnerInfo,
     Lookups,
     MembershipIndex,
@@ -34,261 +31,11 @@ from ._types import (
     Org,
     OrgInfo,
     OrgInfoType,
-    ParentInfo,
     Pillar,
-    RepoInfo,
-    ResourceInfo,
-    RoleInfo,
-    SlackConfig,
     SlackIDMappings,
     Team,
     TeamGroup,
 )
-
-
-def _parse_employee(data: dict[str, Any]) -> Employee:
-    """Parse an Employee from a dictionary."""
-    return Employee(
-        uid=data.get("uid", ""),
-        full_name=data.get("full_name", ""),
-        email=data.get("email", ""),
-        job_title=data.get("job_title", ""),
-        slack_uid=data.get("slack_uid", ""),
-        github_id=data.get("github_id", ""),
-        rhat_geo=data.get("rhat_geo", ""),
-        cost_center=data.get("cost_center", 0),
-        manager_uid=data.get("manager_uid", ""),
-        is_people_manager=data.get("is_people_manager", False),
-        timezone=data.get("timezone", ""),
-    )
-
-
-def _parse_group_type(data: dict[str, Any] | None) -> GroupType:
-    """Parse a GroupType from a dictionary."""
-    if not data:
-        return GroupType()
-    return GroupType(name=data.get("name", ""))
-
-
-def _parse_channel_info(data: dict[str, Any]) -> ChannelInfo:
-    """Parse a ChannelInfo from a dictionary."""
-    return ChannelInfo(
-        channel=data.get("channel", ""),
-        channel_id=data.get("channel_id", ""),
-        description=data.get("description", ""),
-        types=tuple(data.get("types", [])),
-    )
-
-
-def _parse_alias_info(data: dict[str, Any]) -> AliasInfo:
-    """Parse an AliasInfo from a dictionary."""
-    return AliasInfo(
-        alias=data.get("alias", ""),
-        description=data.get("description", ""),
-    )
-
-
-def _parse_slack_config(data: dict[str, Any] | None) -> SlackConfig | None:
-    """Parse a SlackConfig from a dictionary."""
-    if not data:
-        return None
-    return SlackConfig(
-        channels=tuple(_parse_channel_info(c) for c in data.get("channels", [])),
-        aliases=tuple(_parse_alias_info(a) for a in data.get("aliases", [])),
-    )
-
-
-def _parse_role_info(data: dict[str, Any]) -> RoleInfo:
-    """Parse a RoleInfo from a dictionary."""
-    return RoleInfo(
-        people=tuple(data.get("people", [])),
-        roles=tuple(data.get("roles", [])),
-        description=data.get("description", ""),
-    )
-
-
-def _parse_jira_info(data: dict[str, Any]) -> JiraInfo:
-    """Parse a JiraInfo from a dictionary."""
-    return JiraInfo(
-        project=data.get("project", ""),
-        component=data.get("component", ""),
-        description=data.get("description", ""),
-        view=data.get("view", ""),
-        types=tuple(data.get("types", [])),
-    )
-
-
-def _parse_repo_info(data: dict[str, Any]) -> RepoInfo:
-    """Parse a RepoInfo from a dictionary."""
-    return RepoInfo(
-        repo=data.get("repo_name", ""),
-        description=data.get("description", ""),
-        tags=tuple(data.get("tags", [])),
-        path=data.get("path", ""),
-        roles=tuple(data.get("roles", [])),
-        branch=data.get("branch", ""),
-        types=tuple(data.get("types", [])),
-    )
-
-
-def _parse_email_info(data: dict[str, Any]) -> EmailInfo:
-    """Parse an EmailInfo from a dictionary."""
-    return EmailInfo(
-        address=data.get("address", ""),
-        name=data.get("name", ""),
-        description=data.get("description", ""),
-    )
-
-
-def _parse_resource_info(data: dict[str, Any]) -> ResourceInfo:
-    """Parse a ResourceInfo from a dictionary."""
-    return ResourceInfo(
-        name=data.get("name", ""),
-        url=data.get("url", ""),
-        description=data.get("description", ""),
-    )
-
-
-def _parse_component_role_info(data: dict[str, Any]) -> ComponentRoleInfo:
-    """Parse a ComponentRoleInfo from a dictionary."""
-    return ComponentRoleInfo(
-        component=data.get("component", ""),
-        types=tuple(data.get("types", [])),
-    )
-
-
-def _parse_group(data: dict[str, Any] | None) -> Group:
-    """Parse a Group from a dictionary."""
-    if not data:
-        return Group()
-    return Group(
-        type=_parse_group_type(data.get("type")),
-        resolved_people_uid_list=tuple(data.get("resolved_people_uid_list", [])),
-        slack=_parse_slack_config(data.get("slack")),
-        roles=tuple(_parse_role_info(r) for r in data.get("resolved_roles", [])),
-        jiras=tuple(_parse_jira_info(j) for j in data.get("jiras", [])),
-        repos=tuple(_parse_repo_info(r) for r in data.get("repos", [])),
-        keywords=tuple(data.get("keywords", [])),
-        emails=tuple(_parse_email_info(e) for e in data.get("emails", [])),
-        resources=tuple(_parse_resource_info(r) for r in data.get("resources", [])),
-        component_roles=tuple(
-            _parse_component_role_info(c) for c in data.get("component_roles", [])
-        ),
-    )
-
-
-def _parse_parent_info(data: dict[str, Any] | None) -> ParentInfo | None:
-    """Parse a ParentInfo from a dictionary."""
-    if data is None:
-        return None
-    return ParentInfo(
-        name=data.get("name", ""),
-        type=data.get("type", ""),
-    )
-
-
-def _parse_team(data: dict[str, Any]) -> Team:
-    """Parse a Team from a dictionary."""
-    return Team(
-        uid=data.get("uid", ""),
-        name=data.get("name", ""),
-        tab_name=data.get("tab_name", ""),
-        description=data.get("description", ""),
-        type=data.get("type", ""),
-        parent=_parse_parent_info(data.get("parent")),
-        group=_parse_group(data.get("group")),
-    )
-
-
-def _parse_org(data: dict[str, Any]) -> Org:
-    """Parse an Org from a dictionary."""
-    return Org(
-        uid=data.get("uid", ""),
-        name=data.get("name", ""),
-        tab_name=data.get("tab_name", ""),
-        description=data.get("description", ""),
-        type=data.get("type", ""),
-        parent=_parse_parent_info(data.get("parent")),
-        group=_parse_group(data.get("group")),
-    )
-
-
-def _parse_pillar(data: dict[str, Any]) -> Pillar:
-    """Parse a Pillar from a dictionary."""
-    return Pillar(
-        uid=data.get("uid", ""),
-        name=data.get("name", ""),
-        tab_name=data.get("tab_name", ""),
-        description=data.get("description", ""),
-        type=data.get("type", ""),
-        parent=_parse_parent_info(data.get("parent")),
-        group=_parse_group(data.get("group")),
-    )
-
-
-def _parse_team_group(data: dict[str, Any]) -> TeamGroup:
-    """Parse a TeamGroup from a dictionary."""
-    return TeamGroup(
-        uid=data.get("uid", ""),
-        name=data.get("name", ""),
-        tab_name=data.get("tab_name", ""),
-        description=data.get("description", ""),
-        type=data.get("type", ""),
-        parent=_parse_parent_info(data.get("parent")),
-        group=_parse_group(data.get("group")),
-    )
-
-
-def _parse_membership_info(data: dict[str, Any]) -> MembershipInfo:
-    """Parse a MembershipInfo from a dictionary."""
-    return MembershipInfo(
-        name=data.get("name", ""),
-        type=data.get("type", ""),
-    )
-
-
-def _parse_jira_owner_info(data: dict[str, Any]) -> JiraOwnerInfo:
-    """Parse a JiraOwnerInfo from a dictionary."""
-    return JiraOwnerInfo(
-        name=data.get("name", ""),
-        type=data.get("type", ""),
-    )
-
-
-def _parse_component(data: dict[str, Any]) -> Component:
-    """Parse a Component from a dictionary.
-
-    Supports both flat and nested formats. The indexer writes type/repos/jiras
-    under a nested "component" key; this reads top-level fields first, then
-    merges from nested if present.
-    """
-    nested = data.get("component", {})
-
-    # Type: flat is a string, nested is an object {"name": "..."}
-    comp_type = data.get("type", "")
-    if not comp_type and nested:
-        type_val = nested.get("type")
-        if isinstance(type_val, dict):
-            comp_type = type_val.get("name", "")
-        elif isinstance(type_val, str):
-            comp_type = type_val
-
-    repos_raw = data.get("repos") or (nested.get("repos") if nested else []) or []
-    jiras_raw = data.get("jiras") or (nested.get("jiras") if nested else []) or []
-    repos_list_raw = (
-        data.get("repos_list") or (nested.get("repos_list") if nested else []) or []
-    )
-
-    return Component(
-        name=data.get("name", ""),
-        type=comp_type,
-        description=data.get("description", ""),
-        parent=_parse_parent_info(data.get("parent")),
-        parent_path=data.get("parent_path", ""),
-        repos=tuple(_parse_repo_info(r) for r in repos_raw),
-        jiras=tuple(_parse_jira_info(j) for j in jiras_raw),
-        repos_list=tuple(repos_list_raw),
-    )
 
 
 def _parse_jira_index(jira_raw: dict[str, Any]) -> JiraIndex:
@@ -304,39 +51,51 @@ def _parse_jira_index(jira_raw: dict[str, Any]) -> JiraIndex:
             if isinstance(owners, list):
                 owners_list = cast(list[dict[str, Any]], owners)
                 project_component_owners[project][component] = tuple(
-                    _parse_jira_owner_info(o) for o in owners_list
+                    JiraOwnerInfo.model_validate(o) for o in owners_list
                 )
 
     return JiraIndex(project_component_owners=project_component_owners)
 
 
+def _parse_component_ownership_index(raw: dict[str, Any]) -> ComponentOwnershipIndex:
+    """Parse the component ownership index from raw data."""
+    component_owners: dict[str, tuple[ComponentOwnerInfo, ...]] = {}
+
+    for component_name, owners in raw.items():
+        if isinstance(owners, list):
+            owners_list = cast(list[dict[str, Any]], owners)
+            component_owners[component_name] = tuple(
+                ComponentOwnerInfo.model_validate(o) for o in owners_list
+            )
+
+    return ComponentOwnershipIndex(component_owners=component_owners)
+
+
 def parse_data(raw_data: dict[str, Any]) -> Data:
     """Parse the complete Data structure from JSON."""
-    metadata_raw = raw_data.get("metadata", {})
-    metadata = Metadata(
-        generated_at=metadata_raw.get("generated_at", ""),
-        data_version=metadata_raw.get("data_version", ""),
-        total_employees=metadata_raw.get("total_employees", 0),
-        total_orgs=metadata_raw.get("total_orgs", 0),
-        total_teams=metadata_raw.get("total_teams", 0),
-    )
+    metadata = Metadata.model_validate(raw_data.get("metadata", {}))
 
     lookups_raw = raw_data.get("lookups", {})
     lookups = Lookups(
         employees={
-            k: _parse_employee(v) for k, v in lookups_raw.get("employees", {}).items()
+            k: Employee.model_validate(v)
+            for k, v in lookups_raw.get("employees", {}).items()
         },
-        teams={k: _parse_team(v) for k, v in lookups_raw.get("teams", {}).items()},
-        orgs={k: _parse_org(v) for k, v in lookups_raw.get("orgs", {}).items()},
+        teams={
+            k: Team.model_validate(v) for k, v in lookups_raw.get("teams", {}).items()
+        },
+        orgs={k: Org.model_validate(v) for k, v in lookups_raw.get("orgs", {}).items()},
         pillars={
-            k: _parse_pillar(v) for k, v in lookups_raw.get("pillars", {}).items()
+            k: Pillar.model_validate(v)
+            for k, v in lookups_raw.get("pillars", {}).items()
         },
         team_groups={
-            k: _parse_team_group(v)
+            k: TeamGroup.model_validate(v)
             for k, v in lookups_raw.get("team_groups", {}).items()
         },
         components={
-            k: _parse_component(v) for k, v in lookups_raw.get("components", {}).items()
+            k: Component.model_validate(v)
+            for k, v in lookups_raw.get("components", {}).items()
         },
     )
 
@@ -345,7 +104,7 @@ def parse_data(raw_data: dict[str, Any]) -> Data:
 
     membership_index_raw = membership_raw.get("membership_index", {})
     membership_index = {
-        k: tuple(_parse_membership_info(m) for m in v)
+        k: tuple(MembershipInfo.model_validate(m) for m in v)
         for k, v in membership_index_raw.items()
     }
 
@@ -366,11 +125,15 @@ def parse_data(raw_data: dict[str, Any]) -> Data:
     jira_raw = indexes_raw.get("jira", {})
     jira_index = _parse_jira_index(jira_raw)
 
+    component_ownership_raw = indexes_raw.get("component_ownership", {})
+    component_ownership = _parse_component_ownership_index(component_ownership_raw)
+
     indexes = Indexes(
         membership=membership,
         slack_id_mappings=slack_id_mappings,
         github_id_mappings=github_id_mappings,
         jira=jira_index,
+        component_ownership=component_ownership,
     )
 
     return Data(
@@ -661,6 +424,24 @@ class Service:
                 return None
             return self._data.lookups.teams.get(team_name)
 
+    def get_team_escalation(self, team_name: str) -> list[EscalationContactInfo]:
+        """Get the escalation contacts for a team.
+
+        Args:
+            team_name: The team name to look up.
+
+        Returns:
+            Ordered list of escalation contacts, or empty list if team
+            not found or has no escalation data.
+        """
+        with self._lock:
+            if self._data is None or not self._data.lookups.teams:
+                return []
+            team = self._data.lookups.teams.get(team_name)
+            if team is None:
+                return []
+            return list(team.group.escalation)
+
     def get_org_by_name(self, org_name: str) -> Org | None:
         """Get an organization by name."""
         with self._lock:
@@ -702,6 +483,59 @@ class Service:
             if self._data is None or not self._data.lookups.components:
                 return []
             return list(self._data.lookups.components.keys())
+
+    def get_teams_for_component(self, component_name: str) -> list[ComponentOwnerInfo]:
+        """Get all teams/entities that own a component.
+
+        Args:
+            component_name: Component name to look up
+
+        Returns:
+            List of owner entities with ownership types.
+        """
+        with self._lock:
+            if self._data is None:
+                return []
+            owners = self._data.indexes.component_ownership.component_owners.get(
+                component_name, ()
+            )
+            return list(owners)
+
+    def get_components_for_team(self, team_name: str) -> list[ComponentOwnership]:
+        """Get all components owned by a team.
+
+        Uses the team's component_roles list for O(1) team lookup, then
+        resolves ownership types from the component_ownership index.
+
+        Args:
+            team_name: Team name to look up
+
+        Returns:
+            List of ComponentOwnership with component name and ownership types.
+        """
+        with self._lock:
+            if self._data is None:
+                return []
+            team = self._data.lookups.teams.get(team_name)
+            if not team:
+                return []
+            result: list[ComponentOwnership] = []
+            for cr in team.group.component_roles:
+                ownership_types: tuple[str, ...] = ()
+                owners = self._data.indexes.component_ownership.component_owners.get(
+                    cr, ()
+                )
+                for owner in owners:
+                    if owner.name == team_name:
+                        ownership_types = owner.ownership_types
+                        break
+                result.append(
+                    ComponentOwnership(
+                        component=cr,
+                        ownership_types=ownership_types,
+                    )
+                )
+            return result
 
     def get_teams_for_uid(self, uid: str) -> list[str]:
         """Get all teams a UID is a member of."""
@@ -857,6 +691,88 @@ class Service:
             return ""
         return self._data.indexes.slack_id_mappings.slack_uid_to_uid.get(slack_id, "")
 
+    def get_user_memberships(self, uid: str) -> list[MembershipInfo]:
+        """Get all memberships for a user.
+
+        Args:
+            uid: The employee UID.
+
+        Returns:
+            List of membership entries, or empty list if not found.
+        """
+        with self._lock:
+            if self._data is None or not self._data.indexes.membership.membership_index:
+                return []
+            return list(self._data.indexes.membership.membership_index.get(uid, ()))
+
+    def get_user_teams(self, uid: str) -> list[str]:
+        """Get team names for a user.
+
+        Args:
+            uid: The employee UID.
+
+        Returns:
+            List of team names the user belongs to.
+        """
+        with self._lock:
+            return self._get_teams_for_uid(uid)
+
+    def get_all_employees(self) -> list[Employee]:
+        """Get all employees in the system."""
+        with self._lock:
+            if self._data is None or not self._data.lookups.employees:
+                return []
+            return list(self._data.lookups.employees.values())
+
+    def get_all_teams(self) -> list[Team]:
+        """Get all teams in the system."""
+        with self._lock:
+            if self._data is None or not self._data.lookups.teams:
+                return []
+            return list(self._data.lookups.teams.values())
+
+    def get_all_orgs(self) -> list[Org]:
+        """Get all organizations in the system."""
+        with self._lock:
+            if self._data is None or not self._data.lookups.orgs:
+                return []
+            return list(self._data.lookups.orgs.values())
+
+    def get_all_pillars(self) -> list[Pillar]:
+        """Get all pillars in the system."""
+        with self._lock:
+            if self._data is None or not self._data.lookups.pillars:
+                return []
+            return list(self._data.lookups.pillars.values())
+
+    def get_all_team_groups(self) -> list[TeamGroup]:
+        """Get all team groups in the system."""
+        with self._lock:
+            if self._data is None or not self._data.lookups.team_groups:
+                return []
+            return list(self._data.lookups.team_groups.values())
+
+    def get_org_members(self, org_name: str) -> list[Employee]:
+        """Get all members of an organization.
+
+        Args:
+            org_name: The organization name.
+
+        Returns:
+            List of employees in the organization.
+        """
+        with self._lock:
+            if self._data is None or not self._data.lookups.orgs:
+                return []
+            org = self._data.lookups.orgs.get(org_name)
+            if not org:
+                return []
+            return [
+                emp
+                for uid in org.group.resolved_people_uid_list
+                if (emp := self._data.lookups.employees.get(uid))
+            ]
+
     def get_all_employee_uids(self) -> list[str]:
         """Get all employee UIDs in the system."""
         with self._lock:
@@ -870,7 +786,6 @@ class Service:
             if self._data is None or not self._data.lookups.teams:
                 return []
             return list(self._data.lookups.teams.keys())
-
 
     def get_all_org_names(self) -> list[str]:
         """Get all organization names in the system."""

--- a/python/orgdatacore/_types.py
+++ b/python/orgdatacore/_types.py
@@ -1,10 +1,11 @@
 """Type definitions and constants for orgdatacore."""
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import StrEnum
-from typing import BinaryIO, Protocol
+from typing import Any, BinaryIO, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class PIIMode(StrEnum):
@@ -62,9 +63,10 @@ class DataSource(Protocol):
         ...
 
 
-@dataclass(frozen=True, slots=True)
-class Employee:
+class Employee(BaseModel):
     """Represents an employee in the organizational data."""
+
+    model_config = ConfigDict(frozen=True)
 
     uid: str = ""
     full_name: str = ""
@@ -78,10 +80,32 @@ class Employee:
     is_people_manager: bool = False
     timezone: str = ""
 
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_nulls(cls, data: Any) -> Any:
+        """Coerce null string fields to empty strings to match Go zero-value semantics."""
+        if not isinstance(data, dict):
+            return data
+        for key in (
+            "uid",
+            "full_name",
+            "email",
+            "job_title",
+            "slack_uid",
+            "github_id",
+            "rhat_geo",
+            "manager_uid",
+            "timezone",
+        ):
+            if key in data and data[key] is None:
+                data[key] = ""
+        return data
 
-@dataclass(frozen=True, slots=True)
-class ChannelInfo:
+
+class ChannelInfo(BaseModel):
     """Represents a Slack channel configuration."""
+
+    model_config = ConfigDict(frozen=True)
 
     channel: str = ""
     channel_id: str = ""
@@ -89,34 +113,38 @@ class ChannelInfo:
     types: tuple[str, ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class AliasInfo:
+class AliasInfo(BaseModel):
     """Represents a Slack alias configuration."""
+
+    model_config = ConfigDict(frozen=True)
 
     alias: str = ""
     description: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class SlackConfig:
+class SlackConfig(BaseModel):
     """Contains Slack channel and alias configuration."""
+
+    model_config = ConfigDict(frozen=True)
 
     channels: tuple[ChannelInfo, ...] = ()
     aliases: tuple[AliasInfo, ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class RoleInfo:
+class RoleInfo(BaseModel):
     """Represents a role assignment with associated people."""
+
+    model_config = ConfigDict(frozen=True)
 
     people: tuple[str, ...] = ()
     roles: tuple[str, ...] = ()
     description: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class JiraInfo:
+class JiraInfo(BaseModel):
     """Represents Jira project/component configuration."""
+
+    model_config = ConfigDict(frozen=True)
 
     project: str = ""
     component: str = ""
@@ -125,11 +153,12 @@ class JiraInfo:
     types: tuple[str, ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class RepoInfo:
+class RepoInfo(BaseModel):
     """Represents GitHub repository configuration."""
 
-    repo: str = ""
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    repo: str = Field(default="", alias="repo_name")
     description: str = ""
     tags: tuple[str, ...] = ()
     path: str = ""
@@ -138,118 +167,131 @@ class RepoInfo:
     types: tuple[str, ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class EmailInfo:
+class EmailInfo(BaseModel):
     """Represents an email configuration."""
+
+    model_config = ConfigDict(frozen=True)
 
     address: str = ""
     name: str = ""
     description: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class ResourceInfo:
+class ResourceInfo(BaseModel):
     """Represents a resource/documentation link."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str = ""
     url: str = ""
     description: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class ComponentRoleInfo:
-    """Represents component ownership information."""
+class EscalationContactInfo(BaseModel):
+    """Represents an escalation contact for incident response."""
 
-    component: str = ""
-    types: tuple[str, ...] = ()
+    model_config = ConfigDict(frozen=True)
+
+    name: str = ""
+    url: str = ""
+    description: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class GroupType:
+class GroupType(BaseModel):
     """Contains group type information."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class Group:
+class Group(BaseModel):
     """Contains group metadata and configuration."""
 
-    type: GroupType = field(default_factory=GroupType)
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    type: GroupType = Field(default_factory=GroupType)
     resolved_people_uid_list: tuple[str, ...] = ()
     slack: SlackConfig | None = None
-    roles: tuple[RoleInfo, ...] = ()
+    roles: tuple[RoleInfo, ...] = Field(default=(), alias="resolved_roles")
     jiras: tuple[JiraInfo, ...] = ()
     repos: tuple[RepoInfo, ...] = ()
     keywords: tuple[str, ...] = ()
     emails: tuple[EmailInfo, ...] = ()
     resources: tuple[ResourceInfo, ...] = ()
-    component_roles: tuple[ComponentRoleInfo, ...] = ()
+    escalation: tuple[EscalationContactInfo, ...] = ()
+    component_roles: tuple[str, ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class ParentInfo:
+class ParentInfo(BaseModel):
     """Parent reference for hierarchy traversal."""
 
+    model_config = ConfigDict(frozen=True)
+
     name: str = ""
     type: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class Team:
+class Team(BaseModel):
     """Represents a team in the organizational data."""
 
+    model_config = ConfigDict(frozen=True)
+
     uid: str = ""
     name: str = ""
     tab_name: str = ""
     description: str = ""
     type: str = ""
     parent: ParentInfo | None = None
-    group: Group = field(default_factory=Group)
+    group: Group = Field(default_factory=Group)
 
 
-@dataclass(frozen=True, slots=True)
-class Org:
+class Org(BaseModel):
     """Represents an organization in the organizational data."""
 
+    model_config = ConfigDict(frozen=True)
+
     uid: str = ""
     name: str = ""
     tab_name: str = ""
     description: str = ""
     type: str = ""
     parent: ParentInfo | None = None
-    group: Group = field(default_factory=Group)
+    group: Group = Field(default_factory=Group)
 
 
-@dataclass(frozen=True, slots=True)
-class Pillar:
+class Pillar(BaseModel):
     """Represents a pillar in the organizational hierarchy."""
 
+    model_config = ConfigDict(frozen=True)
+
     uid: str = ""
     name: str = ""
     tab_name: str = ""
     description: str = ""
     type: str = ""
     parent: ParentInfo | None = None
-    group: Group = field(default_factory=Group)
+    group: Group = Field(default_factory=Group)
 
 
-@dataclass(frozen=True, slots=True)
-class TeamGroup:
+class TeamGroup(BaseModel):
     """Represents a team group in the organizational hierarchy."""
 
+    model_config = ConfigDict(frozen=True)
+
     uid: str = ""
     name: str = ""
     tab_name: str = ""
     description: str = ""
     type: str = ""
     parent: ParentInfo | None = None
-    group: Group = field(default_factory=Group)
+    group: Group = Field(default_factory=Group)
 
 
-@dataclass(frozen=True, slots=True)
-class Component:
+class Component(BaseModel):
     """Represents a component in the organizational data."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str = ""
     type: str = ""
@@ -260,10 +302,32 @@ class Component:
     jiras: tuple[JiraInfo, ...] = ()
     repos_list: tuple[str, ...] = ()
 
+    @model_validator(mode="before")
+    @classmethod
+    def _flatten_nested(cls, data: Any) -> Any:
+        """Flatten the nested 'component' key from the indexer format."""
+        if not isinstance(data, dict):
+            return data
+        nested = data.get("component", {})
+        if not nested:
+            return data
+        result = dict(data)
+        if not result.get("type"):
+            type_val = nested.get("type")
+            if isinstance(type_val, dict):
+                result["type"] = type_val.get("name", "")
+            elif isinstance(type_val, str):
+                result["type"] = type_val
+        for key in ("repos", "jiras", "repos_list"):
+            if not result.get(key):
+                result[key] = nested.get(key, [])
+        return result
 
-@dataclass(frozen=True, slots=True)
-class Metadata:
+
+class Metadata(BaseModel):
     """Contains summary information about the data."""
+
+    model_config = ConfigDict(frozen=True)
 
     generated_at: str = ""
     data_version: str = ""
@@ -272,130 +336,179 @@ class Metadata:
     total_teams: int = 0
 
 
-@dataclass(frozen=True, slots=True)
-class Lookups:
+class Lookups(BaseModel):
     """Contains the main data objects."""
 
-    employees: dict[str, Employee] = field(default_factory=lambda: {})
-    teams: dict[str, Team] = field(default_factory=lambda: {})
-    orgs: dict[str, Org] = field(default_factory=lambda: {})
-    pillars: dict[str, Pillar] = field(default_factory=lambda: {})
-    team_groups: dict[str, TeamGroup] = field(default_factory=lambda: {})
-    components: dict[str, Component] = field(default_factory=lambda: {})
+    model_config = ConfigDict(frozen=True)
+
+    employees: dict[str, Employee] = Field(default_factory=dict)
+    teams: dict[str, Team] = Field(default_factory=dict)
+    orgs: dict[str, Org] = Field(default_factory=dict)
+    pillars: dict[str, Pillar] = Field(default_factory=dict)
+    team_groups: dict[str, TeamGroup] = Field(default_factory=dict)
+    components: dict[str, Component] = Field(default_factory=dict)
 
 
-@dataclass(frozen=True, slots=True)
-class MembershipInfo:
+class MembershipInfo(BaseModel):
     """Represents a membership entry with name and type."""
 
+    model_config = ConfigDict(frozen=True)
+
     name: str = ""
     type: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class HierarchyPathEntry:
+class HierarchyPathEntry(BaseModel):
     """Single entry in a hierarchy path (name and type)."""
 
+    model_config = ConfigDict(frozen=True)
+
     name: str = ""
     type: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class MembershipIndex:
+class MembershipIndex(BaseModel):
     """Represents the membership index structure."""
 
-    membership_index: dict[str, tuple[MembershipInfo, ...]] = field(
-        default_factory=lambda: {}
+    model_config = ConfigDict(frozen=True)
+
+    membership_index: dict[str, tuple[MembershipInfo, ...]] = Field(
+        default_factory=dict
     )
 
 
-@dataclass(frozen=True, slots=True)
-class SlackIDMappings:
+class SlackIDMappings(BaseModel):
     """Contains Slack ID to UID mappings."""
 
-    slack_uid_to_uid: dict[str, str] = field(default_factory=lambda: {})
+    model_config = ConfigDict(frozen=True)
+
+    slack_uid_to_uid: dict[str, str] = Field(default_factory=dict)
 
 
-@dataclass(frozen=True, slots=True)
-class GitHubIDMappings:
+class GitHubIDMappings(BaseModel):
     """Contains GitHub ID to UID mappings."""
 
-    github_id_to_uid: dict[str, str] = field(default_factory=lambda: {})
+    model_config = ConfigDict(frozen=True)
+
+    github_id_to_uid: dict[str, str] = Field(default_factory=dict)
 
 
-@dataclass(frozen=True, slots=True)
-class HierarchyNode:
+class HierarchyNode(BaseModel):
     """Node in the descendants tree with nested children."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str = ""
     type: str = ""
     children: tuple["HierarchyNode", ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class JiraOwnerInfo:
+class ComponentOwnerInfo(BaseModel):
+    """Represents an entity that owns a component, with ownership type."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = ""
+    type: str = ""
+    ownership_types: tuple[str, ...] = ()
+
+
+class ComponentOwnership(BaseModel):
+    """Represents a component owned by a team, with ownership type."""
+
+    model_config = ConfigDict(frozen=True)
+
+    component: str = ""
+    ownership_types: tuple[str, ...] = ()
+
+
+class JiraOwnerInfo(BaseModel):
     """Represents an entity that owns a Jira project/component."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str = ""
     type: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class JiraIndex:
+class JiraIndex(BaseModel):
     """Contains Jira project/component to team mappings.
 
     Structure: project -> component -> list of owner entities.
     Special key "_project_level" indicates project-level ownership.
     """
 
-    project_component_owners: dict[str, dict[str, tuple[JiraOwnerInfo, ...]]] = field(
-        default_factory=lambda: {}
+    model_config = ConfigDict(frozen=True)
+
+    project_component_owners: dict[str, dict[str, tuple[JiraOwnerInfo, ...]]] = Field(
+        default_factory=dict
     )
 
 
-@dataclass(frozen=True, slots=True)
-class Indexes:
+class ComponentOwnershipIndex(BaseModel):
+    """Contains component-to-team ownership mappings.
+
+    Structure: component_name -> list of owner entities with ownership types.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    component_owners: dict[str, tuple[ComponentOwnerInfo, ...]] = Field(
+        default_factory=dict
+    )
+
+
+class Indexes(BaseModel):
     """Contains pre-computed lookup tables."""
 
-    membership: MembershipIndex = field(default_factory=MembershipIndex)
-    slack_id_mappings: SlackIDMappings = field(default_factory=SlackIDMappings)
-    github_id_mappings: GitHubIDMappings = field(default_factory=GitHubIDMappings)
-    jira: JiraIndex = field(default_factory=JiraIndex)
+    model_config = ConfigDict(frozen=True)
+
+    membership: MembershipIndex = Field(default_factory=MembershipIndex)
+    slack_id_mappings: SlackIDMappings = Field(default_factory=SlackIDMappings)
+    github_id_mappings: GitHubIDMappings = Field(default_factory=GitHubIDMappings)
+    jira: JiraIndex = Field(default_factory=JiraIndex)
+    component_ownership: ComponentOwnershipIndex = Field(
+        default_factory=ComponentOwnershipIndex
+    )
 
 
-@dataclass(frozen=True, slots=True)
-class Data:
+class Data(BaseModel):
     """Represents the comprehensive organizational data structure."""
 
-    metadata: Metadata = field(default_factory=Metadata)
-    lookups: Lookups = field(default_factory=Lookups)
-    indexes: Indexes = field(default_factory=Indexes)
+    model_config = ConfigDict(frozen=True)
+
+    metadata: Metadata = Field(default_factory=Metadata)
+    lookups: Lookups = Field(default_factory=Lookups)
+    indexes: Indexes = Field(default_factory=Indexes)
 
 
-@dataclass(frozen=True, slots=True)
-class OrgInfo:
+class OrgInfo(BaseModel):
     """Represents organization information for a user."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str = ""
     type: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class DataVersion:
+class DataVersion(BaseModel):
     """Tracks the version of loaded data for hot reload."""
 
-    load_time: datetime = field(default_factory=lambda: datetime.min)
-    config_maps: dict[str, str] = field(default_factory=lambda: {})
+    model_config = ConfigDict(frozen=True)
+
+    load_time: datetime = Field(default_factory=lambda: datetime.min)
+    config_maps: dict[str, str] = Field(default_factory=dict)
     org_count: int = 0
     employee_count: int = 0
 
 
-@dataclass(frozen=True, slots=True)
-class GCSConfig:
+class GCSConfig(BaseModel):
     """Represents Google Cloud Storage configuration for data loading."""
+
+    model_config = ConfigDict(frozen=True)
 
     bucket: str = ""
     object_path: str = ""
     project_id: str = ""
     credentials_json: str = ""
-    check_interval: timedelta = field(default_factory=lambda: timedelta(minutes=5))
+    check_interval: timedelta = Field(default_factory=lambda: timedelta(minutes=5))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 keywords = ["organizational-data", "employees", "teams", "organizations"]
 
-dependencies = []
+dependencies = ["pydantic>=2.0"]
 
 [project.optional-dependencies]
 gcs = [
@@ -75,6 +75,10 @@ warn_return_any = true
 warn_unused_ignores = true
 packages = ["orgdatacore"]
 exclude = ["examples", "tests"]
+
+[[tool.mypy.overrides]]
+module = "google.cloud.*"
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "orgdatacore._internal.testing.*"

--- a/python/tests/test_anonymization.py
+++ b/python/tests/test_anonymization.py
@@ -167,8 +167,12 @@ class TestAnonymizingDataSourceAnonymizedMode:
 
         employees = result["lookups"]["employees"]
         for nonce_key, emp in employees.items():
-            assert NONCE_PATTERN.match(nonce_key), f"Key {nonce_key} doesn't match pattern"
-            assert NONCE_PATTERN.match(emp["uid"]), f"uid {emp['uid']} doesn't match pattern"
+            assert NONCE_PATTERN.match(nonce_key), (
+                f"Key {nonce_key} doesn't match pattern"
+            )
+            assert NONCE_PATTERN.match(emp["uid"]), (
+                f"uid {emp['uid']} doesn't match pattern"
+            )
             assert emp["uid"] == nonce_key
 
     def test_names_anonymized(self, sample_data: dict) -> None:
@@ -313,7 +317,9 @@ class TestAnonymizingDataSourceGroups:
 
         result = json.load(source.load())
 
-        people = result["lookups"]["teams"]["test-squad"]["group"]["resolved_people_uid_list"]
+        people = result["lookups"]["teams"]["test-squad"]["group"][
+            "resolved_people_uid_list"
+        ]
         assert len(people) == 2
         for p in people:
             assert NONCE_PATTERN.match(p), f"Person {p} not a nonce"
@@ -324,7 +330,9 @@ class TestAnonymizingDataSourceGroups:
 
         result = json.load(source.load())
 
-        people = result["lookups"]["orgs"]["test-org"]["group"]["resolved_people_uid_list"]
+        people = result["lookups"]["orgs"]["test-org"]["group"][
+            "resolved_people_uid_list"
+        ]
         assert len(people) == 2
         for p in people:
             assert NONCE_PATTERN.match(p)
@@ -502,7 +510,10 @@ class TestAnonymizingDataSourceEdgeCases:
     """Edge case tests."""
 
     def test_empty_employees(self) -> None:
-        data = {"lookups": {"employees": {}}, "indexes": {"membership": {"membership_index": {}}}}
+        data = {
+            "lookups": {"employees": {}},
+            "indexes": {"membership": {"membership_index": {}}},
+        }
         inner = FakeDataSource(data)
         source = AnonymizingDataSource(inner, PIIMode.ANONYMIZED)
 

--- a/python/tests/test_async_service.py
+++ b/python/tests/test_async_service.py
@@ -209,13 +209,17 @@ class TestAsyncService:
 
     @pytest.mark.asyncio
     async def test_get_user_organizations(self) -> None:
-        """Test getting user organizations."""
+        """Test getting user organizations by Slack ID."""
         source = AsyncFakeDataSource(data=create_test_data_json())
         service = AsyncService()
         await service.load_from_data_source(source)
 
-        orgs = await service.get_user_organizations("testuser1")
+        orgs = await service.get_user_organizations("U111111")
         assert len(orgs) > 0
+
+        # Nonexistent Slack ID returns empty
+        orgs2 = await service.get_user_organizations("U999999")
+        assert orgs2 == []
 
     @pytest.mark.asyncio
     async def test_get_all_teams(self) -> None:
@@ -305,7 +309,7 @@ class TestAsyncService:
         assert await service.get_pillar_by_name("test") is None
         assert await service.get_team_group_by_name("test") is None
         assert await service.get_user_teams("test") == []
-        assert await service.get_user_organizations("test") == []
+        assert await service.get_user_organizations("U123") == []
         assert await service.get_all_employees() == []
         assert await service.get_all_teams() == []
         assert await service.get_all_orgs() == []
@@ -325,6 +329,7 @@ class TestAsyncService:
         assert await service.get_descendants_tree("test") is None
         assert await service.get_component_by_name("test") is None
         assert await service.get_all_components() == []
+        assert await service.get_all_component_names() == []
         assert await service.get_jira_projects() == []
         assert await service.get_jira_components("TEST") == []
         assert await service.get_teams_by_jira_project("TEST") == []

--- a/python/tests/test_gcs.py
+++ b/python/tests/test_gcs.py
@@ -1,9 +1,11 @@
 """Tests for GCS data source functionality using fake implementations."""
 
+import importlib.util
+
 import pytest
 
 from orgdatacore import Service
-from orgdatacore._exceptions import GCSError
+from orgdatacore._exceptions import ConfigurationError, GCSError
 from orgdatacore._gcs import GCSDataSource, _retry_with_backoff
 from orgdatacore._internal.testing import (
     FakeGCSClient,
@@ -12,33 +14,30 @@ from orgdatacore._internal.testing import (
 )
 from orgdatacore._types import GCSConfig
 
+_has_gcs = importlib.util.find_spec("google.cloud.storage") is not None
 
-class TestGCSDataSourceStub:
-    """Tests for the GCS stub implementation (when SDK is not available)."""
 
-    def test_stub_load_raises_error(self) -> None:
-        """Test that stub implementation raises GCSError on load."""
+@pytest.mark.skipif(not _has_gcs, reason="google-cloud-storage not installed")
+class TestGCSDataSourceInit:
+    """Tests for GCSDataSource initialization."""
+
+    def test_creates_successfully(self) -> None:
+        """Test that GCSDataSource can be created when google-cloud-storage is installed."""
         config = GCSConfig(bucket="test-bucket", object_path="test/path.json")
         source = GCSDataSource(config)
+        assert "gs://test-bucket/test/path.json" in str(source)
 
-        with pytest.raises(GCSError, match="GCS support not enabled"):
-            source.load()
+    def test_requires_bucket(self) -> None:
+        """Test that empty bucket raises ConfigurationError."""
+        config = GCSConfig(bucket="", object_path="test/path.json")
+        with pytest.raises(ConfigurationError, match="bucket"):
+            GCSDataSource(config)
 
-    def test_stub_watch_returns_error(self) -> None:
-        """Test that stub implementation returns error on watch."""
-        config = GCSConfig(bucket="test-bucket", object_path="test/path.json")
-        source = GCSDataSource(config)
-
-        result = source.watch(lambda: None)
-        assert isinstance(result, GCSError)
-
-    def test_stub_str(self) -> None:
-        """Test stub string representation."""
-        config = GCSConfig(bucket="my-bucket", object_path="data/file.json")
-        source = GCSDataSource(config)
-
-        assert "gs://my-bucket/data/file.json" in str(source)
-        assert "stub" in str(source)
+    def test_requires_object_path(self) -> None:
+        """Test that empty object_path raises ConfigurationError."""
+        config = GCSConfig(bucket="test-bucket", object_path="")
+        with pytest.raises(ConfigurationError, match="object_path"):
+            GCSDataSource(config)
 
 
 class TestFakeGCSClient:

--- a/python/tests/test_mapping.py
+++ b/python/tests/test_mapping.py
@@ -1,0 +1,230 @@
+"""Tests for pydantic model validation and serialization behavior.
+
+Replaces the old _mapping.py unit tests. Validates that pydantic models
+correctly handle JSON parsing, aliased fields, defaults, and round-trips.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from orgdatacore._types import (
+    Component,
+    Employee,
+    Group,
+    GroupType,
+    RepoInfo,
+    RoleInfo,
+    Team,
+)
+
+
+class TestModelValidate:
+    """Tests for Model.model_validate() (JSON dict -> model)."""
+
+    def test_employee_full_data(self):
+        data = {
+            "uid": "jsmith",
+            "full_name": "John Smith",
+            "email": "jsmith@example.com",
+            "job_title": "Engineer",
+            "slack_uid": "U123",
+            "github_id": "jsmith-gh",
+            "rhat_geo": "NA",
+            "cost_center": 42,
+            "manager_uid": "mgr1",
+            "is_people_manager": True,
+            "timezone": "US/Eastern",
+        }
+        emp = Employee.model_validate(data)
+        assert emp.uid == "jsmith"
+        assert emp.full_name == "John Smith"
+        assert emp.cost_center == 42
+        assert emp.is_people_manager is True
+
+    def test_employee_missing_fields_uses_defaults(self):
+        emp = Employee.model_validate({"uid": "x"})
+        assert emp.uid == "x"
+        assert emp.full_name == ""
+        assert emp.cost_center == 0
+        assert emp.is_people_manager is False
+
+    def test_employee_empty_dict(self):
+        emp = Employee.model_validate({})
+        assert emp.uid == ""
+
+    def test_nested_model_validation(self):
+        data = {
+            "uid": "t1",
+            "name": "Team One",
+            "type": "team",
+            "group": {
+                "type": {"name": "dev"},
+                "resolved_people_uid_list": ["a", "b"],
+            },
+        }
+        team = Team.model_validate(data)
+        assert team.group.type.name == "dev"
+        assert team.group.resolved_people_uid_list == ("a", "b")
+
+
+class TestAliasedFields:
+    """Tests for fields with JSON aliases."""
+
+    def test_repo_info_alias(self):
+        """repo_name in JSON maps to repo in Python."""
+        data = {"repo_name": "my-repo", "description": "A repo"}
+        repo = RepoInfo.model_validate(data)
+        assert repo.repo == "my-repo"
+        assert repo.description == "A repo"
+
+    def test_repo_info_by_python_name(self):
+        """Can also construct by Python field name."""
+        repo = RepoInfo(repo="my-repo")
+        assert repo.repo == "my-repo"
+
+    def test_group_resolved_roles_alias(self):
+        """resolved_roles in JSON maps to roles in Python."""
+        data = {
+            "type": {"name": "dev"},
+            "resolved_people_uid_list": [],
+            "resolved_roles": [
+                {"people": ["u1"], "roles": ["lead"], "description": ""}
+            ],
+        }
+        group = Group.model_validate(data)
+        assert len(group.roles) == 1
+        assert group.roles[0].people == ("u1",)
+
+
+class TestModelDump:
+    """Tests for model_dump() (model -> dict)."""
+
+    def test_repo_info_dump_by_alias(self):
+        repo = RepoInfo(repo="my-repo", description="desc")
+        d = repo.model_dump(by_alias=True)
+        assert d["repo_name"] == "my-repo"
+        assert "repo" not in d
+
+    def test_repo_info_dump_by_name(self):
+        repo = RepoInfo(repo="my-repo")
+        d = repo.model_dump()
+        assert d["repo"] == "my-repo"
+
+    def test_group_dump_by_alias(self):
+        group = Group(
+            type=GroupType(name="dev"),
+            roles=(RoleInfo(people=("u1",), roles=("lead",)),),
+        )
+        d = group.model_dump(by_alias=True)
+        assert "resolved_roles" in d
+        assert "roles" not in d
+
+
+class TestComponentNestedValidation:
+    """Tests for Component's model_validator that flattens nested 'component' key."""
+
+    def test_flat_format(self):
+        data = {
+            "name": "comp1",
+            "type": "library",
+            "repos": [{"repo_name": "r1"}],
+        }
+        comp = Component.model_validate(data)
+        assert comp.name == "comp1"
+        assert comp.type == "library"
+        assert len(comp.repos) == 1
+        assert comp.repos[0].repo == "r1"
+
+    def test_nested_format(self):
+        data = {
+            "name": "comp2",
+            "component": {
+                "type": {"name": "service"},
+                "repos": [{"repo_name": "r2"}],
+                "jiras": [{"project": "PROJ", "component": "c1"}],
+                "repos_list": ["repo-a"],
+            },
+        }
+        comp = Component.model_validate(data)
+        assert comp.name == "comp2"
+        assert comp.type == "service"
+        assert len(comp.repos) == 1
+        assert comp.repos[0].repo == "r2"
+        assert len(comp.jiras) == 1
+        assert comp.jiras[0].project == "PROJ"
+        assert comp.repos_list == ("repo-a",)
+
+    def test_nested_type_string(self):
+        data = {
+            "name": "comp3",
+            "component": {"type": "simple-type"},
+        }
+        comp = Component.model_validate(data)
+        assert comp.type == "simple-type"
+
+    def test_flat_overrides_nested(self):
+        data = {
+            "name": "comp4",
+            "type": "flat-type",
+            "component": {"type": {"name": "nested-type"}},
+        }
+        comp = Component.model_validate(data)
+        assert comp.type == "flat-type"
+
+
+class TestRoundTrip:
+    """Tests for validate -> dump -> validate round-trip."""
+
+    def test_employee_round_trip(self):
+        data = {
+            "uid": "jsmith",
+            "full_name": "John Smith",
+            "email": "j@x.com",
+            "job_title": "Eng",
+            "slack_uid": "U1",
+            "github_id": "gh1",
+            "cost_center": 5,
+            "is_people_manager": True,
+        }
+        emp = Employee.model_validate(data)
+        dumped = emp.model_dump()
+        emp2 = Employee.model_validate(dumped)
+        assert emp == emp2
+
+    def test_team_round_trip(self):
+        data = {
+            "uid": "t1",
+            "name": "Team",
+            "type": "team",
+            "group": {
+                "type": {"name": "dev"},
+                "resolved_people_uid_list": ["a"],
+                "resolved_roles": [
+                    {"people": ["a"], "roles": ["lead"], "description": ""}
+                ],
+                "repos": [{"repo_name": "r1", "description": ""}],
+                "jiras": [{"project": "P", "component": "C"}],
+            },
+            "parent": {"name": "org1", "type": "org"},
+        }
+        team = Team.model_validate(data)
+        dumped = team.model_dump(by_alias=True)
+        team2 = Team.model_validate(dumped)
+        assert team == team2
+
+
+class TestFrozenModels:
+    """Tests for frozen model immutability."""
+
+    def test_employee_is_frozen(self):
+        emp = Employee(uid="x")
+        with pytest.raises(ValidationError):
+            emp.uid = "y"  # type: ignore[misc]
+        assert emp.uid == "x"
+
+    def test_model_copy_creates_new_instance(self):
+        emp = Employee(uid="x", full_name="Original")
+        emp2 = emp.model_copy(update={"full_name": "Updated"})
+        assert emp.full_name == "Original"
+        assert emp2.full_name == "Updated"
+        assert emp.uid == emp2.uid

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -5,7 +5,7 @@ from io import BytesIO
 
 import pytest
 
-from orgdatacore import PIIMode, RedactingDataSource, Service
+from orgdatacore import AsyncRedactingDataSource, PIIMode, RedactingDataSource, Service
 
 
 class FakeDataSource:
@@ -81,9 +81,7 @@ def sample_employee_data() -> dict:
 class TestRedactingDataSourceFullMode:
     """Tests for FULL PII mode (pass-through)."""
 
-    def test_full_mode_returns_unchanged_data(
-        self, sample_employee_data: dict
-    ) -> None:
+    def test_full_mode_returns_unchanged_data(self, sample_employee_data: dict) -> None:
         """In FULL mode, data should pass through unchanged."""
         inner = FakeDataSource(sample_employee_data)
         source = RedactingDataSource(inner, PIIMode.FULL)
@@ -122,9 +120,7 @@ class TestRedactingDataSourceFullMode:
 class TestRedactingDataSourceRedactedMode:
     """Tests for REDACTED PII mode."""
 
-    def test_redacted_mode_strips_full_name(
-        self, sample_employee_data: dict
-    ) -> None:
+    def test_redacted_mode_strips_full_name(self, sample_employee_data: dict) -> None:
         """full_name should be replaced with [REDACTED]."""
         inner = FakeDataSource(sample_employee_data)
         source = RedactingDataSource(inner, PIIMode.REDACTED)
@@ -144,10 +140,8 @@ class TestRedactingDataSourceRedactedMode:
         assert result["lookups"]["employees"]["jsmith"]["email"] == "[REDACTED]"
         assert result["lookups"]["employees"]["adoe"]["email"] == "[REDACTED]"
 
-    def test_redacted_mode_clears_slack_uid(
-        self, sample_employee_data: dict
-    ) -> None:
-        """slack_uid should be cleared (omitted from JSON)."""
+    def test_redacted_mode_clears_slack_uid(self, sample_employee_data: dict) -> None:
+        """slack_uid should be cleared."""
         inner = FakeDataSource(sample_employee_data)
         source = RedactingDataSource(inner, PIIMode.REDACTED)
 
@@ -156,10 +150,8 @@ class TestRedactingDataSourceRedactedMode:
         assert result["lookups"]["employees"]["jsmith"].get("slack_uid") is None
         assert result["lookups"]["employees"]["adoe"].get("slack_uid") is None
 
-    def test_redacted_mode_clears_github_id(
-        self, sample_employee_data: dict
-    ) -> None:
-        """github_id should be cleared (omitted from JSON)."""
+    def test_redacted_mode_clears_github_id(self, sample_employee_data: dict) -> None:
+        """github_id should be cleared."""
         inner = FakeDataSource(sample_employee_data)
         source = RedactingDataSource(inner, PIIMode.REDACTED)
 
@@ -182,9 +174,7 @@ class TestRedactingDataSourceRedactedMode:
         assert jsmith["job_title"] == "Senior Engineer"
         assert jsmith["manager_uid"] == "adoe"
 
-    def test_redacted_mode_preserves_metadata(
-        self, sample_employee_data: dict
-    ) -> None:
+    def test_redacted_mode_preserves_metadata(self, sample_employee_data: dict) -> None:
         """Metadata and other lookups should be preserved."""
         inner = FakeDataSource(sample_employee_data)
         source = RedactingDataSource(inner, PIIMode.REDACTED)
@@ -199,9 +189,7 @@ class TestRedactingDataSourceRedactedMode:
 class TestRedactingDataSourceIndexes:
     """Tests for PII index clearing."""
 
-    def test_redacted_mode_clears_slack_index(
-        self, sample_employee_data: dict
-    ) -> None:
+    def test_redacted_mode_clears_slack_index(self, sample_employee_data: dict) -> None:
         """slack_uid_to_uid index should be cleared in redacted mode."""
         inner = FakeDataSource(sample_employee_data)
         source = RedactingDataSource(inner, PIIMode.REDACTED)
@@ -229,7 +217,10 @@ class TestRedactingDataSourceEdgeCases:
 
     def test_empty_employees_dict(self) -> None:
         """Should handle empty employees dict."""
-        data = {"lookups": {"employees": {}}, "indexes": {"membership": {"membership_index": {}}}}
+        data = {
+            "lookups": {"employees": {}},
+            "indexes": {"membership": {"membership_index": {}}},
+        }
         inner = FakeDataSource(data)
         source = RedactingDataSource(inner, PIIMode.REDACTED)
 
@@ -277,6 +268,22 @@ class TestRedactingDataSourceEdgeCases:
         result = json.load(source.load())
 
         assert result["lookups"]["employees"]["jsmith"]["full_name"] == "[REDACTED]"
+
+
+class TestRedactingDataSourceUnsupportedMode:
+    """Tests for unsupported PII modes."""
+
+    def test_anonymized_mode_raises(self, sample_employee_data: dict) -> None:
+        """ANONYMIZED mode should raise ValueError."""
+        inner = FakeDataSource(sample_employee_data)
+        with pytest.raises(ValueError, match="ANONYMIZED"):
+            RedactingDataSource(inner, PIIMode.ANONYMIZED)
+
+    def test_async_anonymized_mode_raises(self, sample_employee_data: dict) -> None:
+        """ANONYMIZED mode should raise ValueError for async variant."""
+        inner = FakeDataSource(sample_employee_data)
+        with pytest.raises(ValueError, match="ANONYMIZED"):
+            AsyncRedactingDataSource(inner, PIIMode.ANONYMIZED)
 
 
 class TestRedactingDataSourceStr:

--- a/python/tests/test_team.py
+++ b/python/tests/test_team.py
@@ -5,9 +5,9 @@ import pytest
 from orgdatacore import (
     AliasInfo,
     ChannelInfo,
-    ComponentRoleInfo,
     Data,
     EmailInfo,
+    EscalationContactInfo,
     GitHubIDMappings,
     Group,
     GroupType,
@@ -255,12 +255,7 @@ class TestGroupExtendedFields:
                                     description="Team wiki",
                                 ),
                             ),
-                            component_roles=(
-                                ComponentRoleInfo(
-                                    component="/component/path",
-                                    types=("owner",),
-                                ),
-                            ),
+                            component_roles=("/component/path",),
                         ),
                     ),
                 },
@@ -286,3 +281,83 @@ class TestGroupExtendedFields:
         assert len(team.group.emails) == 1
         assert len(team.group.resources) == 1
         assert len(team.group.component_roles) == 1
+
+
+class TestGetComponentsForTeam:
+    """Tests for get_components_for_team."""
+
+    def test_returns_components_with_ownership_types(self, service: Service):
+        components = service.get_components_for_team("platform-team")
+        assert len(components) == 2
+        by_name = {c.component: c for c in components}
+        assert "platform-api" in by_name
+        assert "auth-service" in by_name
+        assert "owner" in by_name["platform-api"].ownership_types
+        assert "contributor" in by_name["auth-service"].ownership_types
+
+    def test_single_component_team(self, service: Service):
+        components = service.get_components_for_team("test-team")
+        assert len(components) == 1
+        assert components[0].component == "auth-service"
+        assert "owner" in components[0].ownership_types
+
+    def test_unknown_team_returns_empty(self, service: Service):
+        components = service.get_components_for_team("nonexistent-team")
+        assert components == []
+
+    def test_empty_service_returns_empty(self, empty_service: Service):
+        components = empty_service.get_components_for_team("test-team")
+        assert components == []
+
+
+class TestGetTeamEscalation:
+    """Tests for team escalation contact lookup."""
+
+    def test_returns_escalation_contacts(self, service: Service):
+        """Test that escalation contacts are returned for a team that has them."""
+        result = service.get_team_escalation("platform-team")
+
+        assert len(result) == 2
+        assert result[0].name == "Platform on-call"
+        assert result[0].url == "https://redhat.enterprise.slack.com/archives/C003"
+        assert (
+            result[0].description == "Primary on-call engineer for platform incidents."
+        )
+        assert result[1].name == "Platform team"
+
+    def test_returns_empty_for_team_without_escalation(self, service: Service):
+        """Test that empty list is returned for a team with no escalation data."""
+        result = service.get_team_escalation("test-team")
+
+        assert result == []
+
+    def test_returns_empty_for_nonexistent_team(self, service: Service):
+        """Test that empty list is returned for a nonexistent team."""
+        result = service.get_team_escalation("nonexistent-team")
+
+        assert result == []
+
+    def test_returns_empty_for_empty_service(self, empty_service: Service):
+        """Test that empty list is returned when no data is loaded."""
+        result = empty_service.get_team_escalation("platform-team")
+
+        assert result == []
+
+    def test_escalation_contacts_are_ordered(self, service: Service):
+        """Test that escalation contacts preserve insertion order."""
+        result = service.get_team_escalation("platform-team")
+
+        names = [c.name for c in result]
+        assert names == ["Platform on-call", "Platform team"]
+
+    def test_escalation_contact_fields(self):
+        """Test EscalationContactInfo dataclass fields."""
+        contact = EscalationContactInfo(
+            name="Test monitor",
+            url="https://example.com/channel",
+            description="Test escalation path",
+        )
+
+        assert contact.name == "Test monitor"
+        assert contact.url == "https://example.com/channel"
+        assert contact.description == "Test escalation path"

--- a/testdata/test_org_data.json
+++ b/testdata/test_org_data.json
@@ -67,7 +67,10 @@
           "repos": [
             {"repo_name": "https://github.com/example/test-repo", "description": "Main test repository"}
           ],
-          "keywords": ["testing", "qa"]
+          "keywords": ["testing", "qa"],
+          "component_roles": [
+            "auth-service"
+          ]
         }
       },
       "platform-team": {
@@ -93,6 +96,22 @@
           ],
           "repos": [
             {"repo_name": "https://github.com/example/platform", "description": "Platform monorepo"}
+          ],
+          "escalation": [
+            {
+              "name": "Platform on-call",
+              "url": "https://redhat.enterprise.slack.com/archives/C003",
+              "description": "Primary on-call engineer for platform incidents."
+            },
+            {
+              "name": "Platform team",
+              "url": "https://redhat.enterprise.slack.com/archives/C003",
+              "description": "Entire platform team for escalation."
+            }
+          ],
+          "component_roles": [
+            "platform-api",
+            "auth-service"
           ]
         }
       }
@@ -221,6 +240,15 @@
           {"name": "platform-team", "type": "team"}
         ]
       }
+    },
+    "component_ownership": {
+      "platform-api": [
+        {"name": "platform-team", "type": "team", "ownership_types": ["owner"]}
+      ],
+      "auth-service": [
+        {"name": "test-team", "type": "team", "ownership_types": ["owner"]},
+        {"name": "platform-team", "type": "team", "ownership_types": ["contributor"]}
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds 11 new service methods to both Go and Python for full API parity, migrates Python data types from dataclasses to pydantic v2, and cleans up post-migration issues.

### Go

- Added 11 new Service methods: `GetUserMemberships`, `GetUserTeams`, `GetAllEmployees`, `GetAllTeams`, `GetAllOrgs`, `GetAllPillars`, `GetAllTeamGroups`, `GetOrgMembers`, `GetTeamEscalation`, `GetTeamsForComponent`, `GetComponentsForTeam`
- Added types: `EscalationContactInfo`, `ComponentOwnerInfo`, `ComponentOwnership`
- Changed `Group.ComponentRoles` from `[]ComponentRoleInfo` to `[]string`
- Added `Indexes.ComponentOwnership` map for component-to-team lookups
- Updated `ServiceInterface` with all new methods

### Python

- Migrated all data types from dataclasses to pydantic v2 `BaseModel` with `ConfigDict(frozen=True)`
- Added matching sync/async Service methods for full API parity
- Added `Employee._coerce_nulls` model validator to handle null string fields from upstream data (coerces to `""` to match Go zero-value semantics)
- Refactored GCS data sources: merged stub and SDK classes into single `GCSDataSource`/`AsyncGCSDataSource` that raise `ImportError` at init
- Added `AsyncRedactingDataSource`
- Exported `Component` from public API
- Removed unnecessary `populate_by_name`/`arbitrary_types_allowed` config from 34 models that don't use aliases
- Updated `python/CLAUDE.md` to reflect pydantic patterns

### Parity

- Updated Go and Python parity runners with serializers for all new return types
- Refactored Python runner to use `EntityConfig` registry instead of per-type branches

### Test data

- Added escalation contacts, `component_roles`, and `component_ownership` index to shared test fixtures