### PR TITLE
Add GetTeamBySlackChannel for team lookup by Slack channel name

### DIFF
--- a/go/interface.go
+++ b/go/interface.go
@@ -31,6 +31,7 @@ type ServiceInterface interface {
 	GetEmployeeByEmail(email string) *Employee
 	GetManagerForEmployee(uid string) *Employee
 	GetTeamByName(teamName string) *Team
+	GetTeamsBySlackChannel(channel string) []Team
 	GetOrgByName(orgName string) *Org
 	GetPillarByName(pillarName string) *Pillar
 	GetTeamGroupByName(teamGroupName string) *TeamGroup

--- a/go/service.go
+++ b/go/service.go
@@ -11,12 +11,13 @@ import (
 )
 
 type Service struct {
-	mu             sync.RWMutex
-	data           *Data
-	version        DataVersion
-	logger         *slog.Logger
-	watcherRunning bool
-	watcherCancel  context.CancelFunc
+	mu                sync.RWMutex
+	data              *Data
+	version           DataVersion
+	logger            *slog.Logger
+	watcherRunning    bool
+	watcherCancel     context.CancelFunc
+	slackChannelIndex map[string][]string
 }
 
 func NewService(opts ...ServiceOption) *Service {
@@ -55,6 +56,19 @@ func (s *Service) LoadFromDataSource(ctx context.Context, source DataSource) err
 		LoadTime:      time.Now(),
 		OrgCount:      len(orgData.Lookups.Orgs),
 		EmployeeCount: len(orgData.Lookups.Employees),
+	}
+
+	s.slackChannelIndex = make(map[string][]string)
+	for _, team := range orgData.Lookups.Teams {
+		if team.Group.Slack == nil {
+			continue
+		}
+		for _, ch := range team.Group.Slack.Channels {
+			if ch.Channel != "" {
+				normalized := normalizeSlackChannel(ch.Channel)
+				s.slackChannelIndex[normalized] = append(s.slackChannelIndex[normalized], team.Name)
+			}
+		}
 	}
 
 	s.logger.Info("data loaded", "source", source.String(), "employees", s.version.EmployeeCount, "orgs", s.version.OrgCount)
@@ -237,6 +251,35 @@ func (s *Service) GetTeamByName(teamName string) *Team {
 		return &team
 	}
 	return nil
+}
+
+func normalizeSlackChannel(channel string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(channel), "#"))
+}
+
+func (s *Service) GetTeamsBySlackChannel(channel string) []Team {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data == nil || s.slackChannelIndex == nil || channel == "" {
+		return []Team{}
+	}
+
+	teamNames, exists := s.slackChannelIndex[normalizeSlackChannel(channel)]
+	if !exists {
+		return []Team{}
+	}
+
+	var teams []Team
+	for _, name := range teamNames {
+		if team, exists := s.data.Lookups.Teams[name]; exists {
+			teams = append(teams, team)
+		}
+	}
+	if teams == nil {
+		return []Team{}
+	}
+	return teams
 }
 
 func (s *Service) GetOrgByName(orgName string) *Org {

--- a/go/team_test.go
+++ b/go/team_test.go
@@ -59,6 +59,79 @@ func TestGetTeamByName(t *testing.T) {
 	}
 }
 
+// TestGetTeamsBySlackChannel tests team lookup by Slack channel name
+func TestGetTeamsBySlackChannel(t *testing.T) {
+	service := setupTestService(t)
+
+	tests := []struct {
+		name          string
+		channel       string
+		expectedNames []string
+	}{
+		{
+			name:          "channel with hash prefix",
+			channel:       "#test-team",
+			expectedNames: []string{"test-team"},
+		},
+		{
+			name:          "channel without hash prefix",
+			channel:       "platform",
+			expectedNames: []string{"platform-team"},
+		},
+		{
+			name:          "non-main channel",
+			channel:       "test-alerts",
+			expectedNames: []string{"test-team"},
+		},
+		{
+			name:          "case insensitive",
+			channel:       "#Test-Team",
+			expectedNames: []string{"test-team"},
+		},
+		{
+			name:          "nonexistent channel",
+			channel:       "nonexistent",
+			expectedNames: []string{},
+		},
+		{
+			name:          "empty channel",
+			channel:       "",
+			expectedNames: []string{},
+		},
+		{
+			name:          "whitespace padded",
+			channel:       "  #test-team  ",
+			expectedNames: []string{"test-team"},
+		},
+		{
+			name:          "hash only",
+			channel:       "#",
+			expectedNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.GetTeamsBySlackChannel(tt.channel)
+
+			var resultNames []string
+			for _, team := range result {
+				resultNames = append(resultNames, team.Name)
+			}
+
+			sort.Strings(resultNames)
+			sort.Strings(tt.expectedNames)
+
+			if len(resultNames) == 0 && len(tt.expectedNames) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(resultNames, tt.expectedNames) {
+				t.Errorf("GetTeamsBySlackChannel(%q) = %v, expected %v", tt.channel, resultNames, tt.expectedNames)
+			}
+		})
+	}
+}
+
 // TestGetTeamsForUID tests team membership lookup by UID
 func TestGetTeamsForUID(t *testing.T) {
 	service := setupTestService(t)

--- a/python/orgdatacore/_async.py
+++ b/python/orgdatacore/_async.py
@@ -26,7 +26,7 @@ from typing import Any, BinaryIO
 
 from ._exceptions import ConfigurationError, DataLoadError, GCSError
 from ._log import get_logger
-from ._service import parse_data
+from ._service import _normalize_slack_channel, parse_data
 from ._types import (
     Component,
     ComponentOwnerInfo,
@@ -82,6 +82,7 @@ class AsyncService:
         self._watcher_running = False
         self._watcher_task: asyncio.Task[None] | None = None
         self._watcher_source: Any | None = None
+        self._slack_channel_index: dict[str, list[str]] = {}
 
     async def initialize(self) -> None:
         """Initialize the service if a data source was provided.
@@ -149,6 +150,15 @@ class AsyncService:
                 org_count=len(org_data.lookups.orgs),
                 employee_count=len(org_data.lookups.employees),
             )
+
+            self._slack_channel_index = {}
+            for team in org_data.lookups.teams.values():
+                if team.group.slack is None:
+                    continue
+                for ch in team.group.slack.channels:
+                    if ch.channel:
+                        normalized = _normalize_slack_channel(ch.channel)
+                        self._slack_channel_index.setdefault(normalized, []).append(team.name)
 
         logger.info(
             "Data loaded successfully (async)",
@@ -345,6 +355,29 @@ class AsyncService:
             if self._data is None:
                 return None
             return self._data.lookups.teams.get(team_name)
+
+    async def get_teams_by_slack_channel(self, channel: str) -> list[Team]:
+        """Get teams associated with a Slack channel name.
+
+        Args:
+            channel: Slack channel name (e.g., "#test-team" or "test-team").
+                     The "#" prefix and casing are ignored.
+
+        Returns:
+            List of matching teams, or empty list if none found.
+        """
+        async with self._lock:
+            if self._data is None or not channel:
+                return []
+
+            team_names = self._slack_channel_index.get(
+                _normalize_slack_channel(channel), []
+            )
+            return [
+                self._data.lookups.teams[name]
+                for name in team_names
+                if name in self._data.lookups.teams
+            ]
 
     async def get_team_escalation(self, team_name: str) -> list[EscalationContactInfo]:
         """Get the escalation contacts for a team.

--- a/python/orgdatacore/_service.py
+++ b/python/orgdatacore/_service.py
@@ -38,6 +38,10 @@ from ._types import (
 )
 
 
+def _normalize_slack_channel(channel: str) -> str:
+    return channel.strip().lstrip("#").lower()
+
+
 def _parse_jira_index(jira_raw: dict[str, Any]) -> JiraIndex:
     """Parse the Jira index from raw data."""
     project_component_owners: dict[str, dict[str, tuple[JiraOwnerInfo, ...]]] = {}
@@ -184,6 +188,7 @@ class Service:
         self._version = DataVersion()
         self._watcher_running = False
         self._stop_event = threading.Event()
+        self._slack_channel_index: dict[str, list[str]] = {}
 
         if data_source is not None:
             self.load_from_data_source(data_source)
@@ -241,6 +246,15 @@ class Service:
                 org_count=len(org_data.lookups.orgs),
                 employee_count=len(org_data.lookups.employees),
             )
+
+            self._slack_channel_index = {}
+            for team in org_data.lookups.teams.values():
+                if team.group.slack is None:
+                    continue
+                for ch in team.group.slack.channels:
+                    if ch.channel:
+                        normalized = _normalize_slack_channel(ch.channel)
+                        self._slack_channel_index.setdefault(normalized, []).append(team.name)
 
         logger.info(
             "Data loaded successfully",
@@ -423,6 +437,29 @@ class Service:
             if self._data is None or not self._data.lookups.teams:
                 return None
             return self._data.lookups.teams.get(team_name)
+
+    def get_teams_by_slack_channel(self, channel: str) -> list[Team]:
+        """Get teams associated with a Slack channel name.
+
+        Args:
+            channel: Slack channel name (e.g., "#test-team" or "test-team").
+                     The "#" prefix and casing are ignored.
+
+        Returns:
+            List of matching teams, or empty list if none found.
+        """
+        with self._lock:
+            if self._data is None or not channel:
+                return []
+
+            team_names = self._slack_channel_index.get(
+                _normalize_slack_channel(channel), []
+            )
+            return [
+                self._data.lookups.teams[name]
+                for name in team_names
+                if name in self._data.lookups.teams
+            ]
 
     def get_team_escalation(self, team_name: str) -> list[EscalationContactInfo]:
         """Get the escalation contacts for a team.

--- a/python/tests/test_team.py
+++ b/python/tests/test_team.py
@@ -54,6 +54,34 @@ class TestGetTeamByName:
             assert result is None
 
 
+class TestGetTeamsBySlackChannel:
+    """Tests for team lookup by Slack channel name."""
+
+    @pytest.mark.parametrize(
+        "channel,expected_names",
+        [
+            ("#test-team", ["test-team"]),
+            ("platform", ["platform-team"]),
+            ("test-alerts", ["test-team"]),
+            ("#Test-Team", ["test-team"]),
+            ("nonexistent", []),
+            ("", []),
+            ("  #test-team  ", ["test-team"]),
+            ("#", []),
+        ],
+    )
+    def test_get_teams_by_slack_channel(
+        self,
+        service: Service,
+        channel: str,
+        expected_names: list[str],
+    ):
+        """Test team lookup by Slack channel name."""
+        result = service.get_teams_by_slack_channel(channel)
+        result_names = sorted(t.name for t in result)
+        assert result_names == sorted(expected_names)
+
+
 class TestGetTeamsForUID:
     """Tests for team membership lookup by UID."""
 


### PR DESCRIPTION
## Summary

- Adds `GetTeamBySlackChannel` (Go) / `get_team_by_slack_channel` (Python) for looking up a team by its Slack channel name
- Builds a reverse-lookup index at data load time (channel name → team name) for O(1) queries
- Input is normalized (strip `#` prefix, lowercase) so `#Test-Team`, `test-team`, and `#test-team` all resolve correctly
- Includes async support in Python's `AsyncService`