### PR TITLE
VALORFLOW-16: Add ldap group retrieval to groups

### DIFF
--- a/go/team_test.go
+++ b/go/team_test.go
@@ -653,3 +653,30 @@ func TestGroupExtendedFields(t *testing.T) {
 		t.Errorf("expected 1 component role, got %d", len(team.Group.ComponentRoles))
 	}
 }
+
+func TestTeamPeopleLDAPGroups(t *testing.T) {
+	service := setupTestService(t)
+
+	team := service.GetTeamByName("test-team")
+	if team == nil {
+		t.Fatal("expected team, got nil")
+	}
+
+	if len(team.Group.PeopleLDAPGroups) != 1 {
+		t.Fatalf("expected 1 LDAP group, got %d", len(team.Group.PeopleLDAPGroups))
+	}
+	if team.Group.PeopleLDAPGroups[0] != "test-team-ldap" {
+		t.Errorf("expected LDAP group 'test-team-ldap', got '%s'", team.Group.PeopleLDAPGroups[0])
+	}
+
+	platform := service.GetTeamByName("platform-team")
+	if platform == nil {
+		t.Fatal("expected platform-team, got nil")
+	}
+	if len(platform.Group.PeopleLDAPGroups) != 1 {
+		t.Fatalf("expected 1 LDAP group for platform-team, got %d", len(platform.Group.PeopleLDAPGroups))
+	}
+	if platform.Group.PeopleLDAPGroups[0] != "platform-team-ldap" {
+		t.Errorf("expected LDAP group 'platform-team-ldap', got '%s'", platform.Group.PeopleLDAPGroups[0])
+	}
+}

--- a/go/types.go
+++ b/go/types.go
@@ -140,6 +140,7 @@ type Team struct {
 type Group struct {
 	Type                  GroupType           `json:"type"`
 	ResolvedPeopleUIDList []string            `json:"resolved_people_uid_list"`
+	PeopleLDAPGroups      []string            `json:"people_ldap_groups,omitempty"`
 	Slack                 *SlackConfig        `json:"slack,omitempty"`
 	Roles                 []RoleInfo          `json:"resolved_roles,omitempty"`
 	Jiras                 []JiraInfo          `json:"jiras,omitempty"`

--- a/python/orgdatacore/_types.py
+++ b/python/orgdatacore/_types.py
@@ -227,6 +227,7 @@ class Group(BaseModel):
 
     type: GroupType = Field(default_factory=GroupType)
     resolved_people_uid_list: tuple[str, ...] = ()
+    people_ldap_groups: tuple[str, ...] = ()
     slack: SlackConfig | None = None
     roles: tuple[RoleInfo, ...] = Field(default=(), alias="resolved_roles")
     jiras: tuple[JiraInfo, ...] = ()

--- a/testdata/test_org_data.json
+++ b/testdata/test_org_data.json
@@ -56,6 +56,7 @@
         "group": {
           "type": {"name": "team", "visualize": true},
           "resolved_people_uid_list": ["jsmith", "adoe"],
+          "people_ldap_groups": ["test-team-ldap"],
           "resolved_roles": [
             {"people": ["adoe"], "roles": ["manager"]},
             {"people": ["jsmith"], "roles": ["tech_lead"]}
@@ -88,6 +89,7 @@
         "group": {
           "type": {"name": "team", "visualize": true},
           "resolved_people_uid_list": ["bwilson"],
+          "people_ldap_groups": ["platform-team-ldap"],
           "resolved_roles": [
             {"people": ["bwilson"], "roles": ["tech_lead"]}
           ],


### PR DESCRIPTION
Trying to set up default owners files via LDAP groups for github, it appears that the ldap groups are in the index, but aren't retrieved by group lookups?

It doesn't seem like it should hurt anything to retrieve that too -- I'm assuming it was more that nobody had a need to use it yet vs an intentional exclusion. If there was a good reason this was omitted from the fields retrieved, let me know :smile: 

This just adds people_ldap_groups to the list of fields returned by the group struct so I can get at them.

