### PR TITLE
Support loading PII-free indexes

### DIFF
--- a/go/service.go
+++ b/go/service.go
@@ -1166,6 +1166,12 @@ func (s *Service) GetContextTypeDescriptions() map[string]string {
 // validateData checks that required data structures are present.
 func validateData(data *Data) error {
 	if data.Metadata.PIIFree {
+		if len(data.Lookups.Employees) > 0 {
+			return fmt.Errorf("%w: pii_free is set but lookups.employees is not empty", ErrInvalidData)
+		}
+		if len(data.Indexes.Membership.MembershipIndex) > 0 {
+			return fmt.Errorf("%w: pii_free is set but membership_index is not empty", ErrInvalidData)
+		}
 		return nil
 	}
 	if len(data.Lookups.Employees) == 0 {

--- a/go/service.go
+++ b/go/service.go
@@ -1165,6 +1165,9 @@ func (s *Service) GetContextTypeDescriptions() map[string]string {
 
 // validateData checks that required data structures are present.
 func validateData(data *Data) error {
+	if data.Metadata.PIIFree {
+		return nil
+	}
 	if len(data.Lookups.Employees) == 0 {
 		return fmt.Errorf("%w: missing lookups.employees", ErrInvalidData)
 	}

--- a/go/service_test.go
+++ b/go/service_test.go
@@ -100,6 +100,46 @@ func TestLoadFromDataSource(t *testing.T) {
 	}
 }
 
+// TestLoadPIIFreeData tests that PII-free data loads without validation errors
+func TestLoadPIIFreeData(t *testing.T) {
+	service := NewService()
+	testDataPath := filepath.Join("..", "testdata", "test_org_data_pii_free.json")
+	fileSource := testingsupport.NewFileDataSource(testDataPath)
+
+	err := service.LoadFromDataSource(context.Background(), fileSource)
+	if err != nil {
+		t.Fatalf("Failed to load PII-free data: %v", err)
+	}
+
+	version := service.GetVersion()
+	if version.EmployeeCount != 0 {
+		t.Errorf("Expected 0 employees, got %d", version.EmployeeCount)
+	}
+	if version.OrgCount != 2 {
+		t.Errorf("Expected 2 orgs, got %d", version.OrgCount)
+	}
+
+	// Team queries should still work
+	team := service.GetTeamByName("test-team")
+	if team == nil {
+		t.Fatal("Expected to find test-team")
+	}
+	if team.Name != "test-team" {
+		t.Errorf("Expected team name 'test-team', got %q", team.Name)
+	}
+
+	// Employee queries should return nil
+	if emp := service.GetEmployeeByUID("jsmith"); emp != nil {
+		t.Error("Expected nil for employee lookup in PII-free data")
+	}
+
+	// Org queries should work
+	org := service.GetOrgByName("test-org")
+	if org == nil {
+		t.Fatal("Expected to find test-org")
+	}
+}
+
 // TestGetVersion tests version information
 func TestGetVersion(t *testing.T) {
 	service := NewService()

--- a/go/types.go
+++ b/go/types.go
@@ -172,6 +172,7 @@ type Metadata struct {
 	TotalEmployees          int               `json:"total_employees"`
 	TotalOrgs               int               `json:"total_orgs"`
 	TotalTeams              int               `json:"total_teams"`
+	PIIFree                 bool              `json:"pii_free,omitempty"`
 	ContextTypeDescriptions map[string]string `json:"context_type_descriptions,omitempty"`
 }
 

--- a/python/orgdatacore/_async.py
+++ b/python/orgdatacore/_async.py
@@ -273,8 +273,7 @@ class AsyncService:
         """Check if the service is ready to serve requests."""
         if self._data is None:
             return False
-        # Data has lookups and indexes (always present when data is loaded)
-        return bool(self._data.lookups.employees)
+        return bool(self._data.lookups.employees) or self._data.metadata.pii_free
 
     def get_data_age(self) -> timedelta:
         """Get the duration since data was last loaded.

--- a/python/orgdatacore/_service.py
+++ b/python/orgdatacore/_service.py
@@ -147,6 +147,14 @@ def parse_data(raw_data: dict[str, Any]) -> Data:
 def _validate_data(data: Data, source: DataSource) -> None:
     """Validate that required data structures are present."""
     if data.metadata.pii_free:
+        if data.lookups.employees:
+            raise DataLoadError(
+                f"invalid data from {source}: pii_free is set but lookups.employees is not empty"
+            )
+        if data.indexes.membership.membership_index:
+            raise DataLoadError(
+                f"invalid data from {source}: pii_free is set but membership_index is not empty"
+            )
         return
     if not data.lookups.employees:
         raise DataLoadError(f"invalid data from {source}: missing lookups.employees")

--- a/python/orgdatacore/_service.py
+++ b/python/orgdatacore/_service.py
@@ -146,6 +146,8 @@ def parse_data(raw_data: dict[str, Any]) -> Data:
 
 def _validate_data(data: Data, source: DataSource) -> None:
     """Validate that required data structures are present."""
+    if data.metadata.pii_free:
+        return
     if not data.lookups.employees:
         raise DataLoadError(f"invalid data from {source}: missing lookups.employees")
     if not data.indexes.membership.membership_index:
@@ -317,8 +319,7 @@ class Service:
         with self._lock:
             if self._data is None:
                 return False
-            # Data has lookups and indexes (always present when data is loaded)
-            return bool(self._data.lookups.employees)
+            return bool(self._data.lookups.employees) or self._data.metadata.pii_free
 
     def get_version(self) -> DataVersion:
         """Get the current data version."""

--- a/python/orgdatacore/_types.py
+++ b/python/orgdatacore/_types.py
@@ -353,6 +353,7 @@ class Metadata(BaseModel):
     total_employees: int = 0
     total_orgs: int = 0
     total_teams: int = 0
+    pii_free: bool = False
     context_type_descriptions: dict[str, str] = Field(default_factory=dict)
 
 

--- a/python/tests/test_service.py
+++ b/python/tests/test_service.py
@@ -11,6 +11,21 @@ from orgdatacore import DataLoadError, Service
 from orgdatacore._internal.testing import FakeDataSource, FileDataSource
 
 
+@pytest.fixture
+def pii_free_data_path() -> Path:
+    """Get path to the PII-free test data file."""
+    return Path(__file__).parent.parent.parent / "testdata" / "test_org_data_pii_free.json"
+
+
+@pytest.fixture
+def pii_free_service(pii_free_data_path: Path) -> Service:
+    """Create a service loaded with PII-free test data."""
+    svc = Service()
+    file_source = FileDataSource(str(pii_free_data_path))
+    svc.load_from_data_source(file_source)
+    return svc
+
+
 class TestNewService:
     """Tests for service creation."""
 
@@ -174,3 +189,41 @@ class TestHealthCheck:
     def test_is_ready_with_data(self, service: Service):
         """Service should be ready with data loaded."""
         assert service.is_ready() is True
+
+
+class TestPIIFreeData:
+    """Tests for PII-free data loading and behavior."""
+
+    def test_load_pii_free_data(self, pii_free_data_path: Path):
+        """Loading PII-free data should succeed without validation errors."""
+        service = Service()
+        file_source = FileDataSource(str(pii_free_data_path))
+        service.load_from_data_source(file_source)
+
+        version = service.get_version()
+        assert version.employee_count == 0
+        assert version.org_count == 2
+
+    def test_is_healthy_with_pii_free_data(self, pii_free_service: Service):
+        """Service should be healthy with PII-free data loaded."""
+        assert pii_free_service.is_healthy() is True
+
+    def test_is_ready_with_pii_free_data(self, pii_free_service: Service):
+        """Service should be ready with PII-free data loaded."""
+        assert pii_free_service.is_ready() is True
+
+    def test_team_queries_work(self, pii_free_service: Service):
+        """Team queries should work with PII-free data."""
+        team = pii_free_service.get_team_by_name("test-team")
+        assert team is not None
+        assert team.name == "test-team"
+
+    def test_employee_queries_return_none(self, pii_free_service: Service):
+        """Employee queries should return None with PII-free data."""
+        assert pii_free_service.get_employee_by_uid("jsmith") is None
+
+    def test_org_queries_work(self, pii_free_service: Service):
+        """Org queries should work with PII-free data."""
+        org = pii_free_service.get_org_by_name("test-org")
+        assert org is not None
+        assert org.name == "test-org"

--- a/python/tests/test_service.py
+++ b/python/tests/test_service.py
@@ -227,3 +227,40 @@ class TestPIIFreeData:
         org = pii_free_service.get_org_by_name("test-org")
         assert org is not None
         assert org.name == "test-org"
+
+    def test_rejects_pii_free_with_employees(self):
+        """Should reject data claiming pii_free but containing employees."""
+        import json
+
+        data = {
+            "metadata": {"pii_free": True},
+            "lookups": {
+                "employees": {"uid1": {"uid": "uid1", "full_name": "Test"}},
+                "teams": {},
+            },
+            "indexes": {"membership": {"membership_index": {}}},
+        }
+        source = FakeDataSource(data=json.dumps(data))
+        service = Service()
+        with pytest.raises(DataLoadError, match="pii_free is set but lookups.employees is not empty"):
+            service.load_from_data_source(source)
+
+    def test_rejects_pii_free_with_membership(self):
+        """Should reject data claiming pii_free but containing membership data."""
+        import json
+
+        data = {
+            "metadata": {"pii_free": True},
+            "lookups": {"employees": {}, "teams": {}},
+            "indexes": {
+                "membership": {
+                    "membership_index": {
+                        "uid1": [{"name": "team1", "type": "team"}]
+                    }
+                }
+            },
+        }
+        source = FakeDataSource(data=json.dumps(data))
+        service = Service()
+        with pytest.raises(DataLoadError, match="pii_free is set but membership_index is not empty"):
+            service.load_from_data_source(source)

--- a/testdata/test_org_data_pii_free.json
+++ b/testdata/test_org_data_pii_free.json
@@ -1,0 +1,147 @@
+{
+  "metadata": {
+    "generated_at": "2024-01-15T12:00:00.000000",
+    "data_version": "test-abc123-pii-free",
+    "total_employees": 0,
+    "total_orgs": 2,
+    "total_teams": 2,
+    "total_pillars": 1,
+    "total_team_groups": 1,
+    "pii_free": true,
+    "context_type_descriptions": {
+      "team_overview": "Overview of a team/group/org: purpose, scope, how it fits within the larger organization.",
+      "release_framework": "High-level release strategy and cadence."
+    }
+  },
+  "lookups": {
+    "employees": {},
+    "teams": {
+      "test-team": {
+        "uid": "team-001",
+        "name": "test-team",
+        "description": "Core testing and QA team",
+        "type": "team",
+        "parent": {"name": "test-org", "type": "org"},
+        "group": {
+          "type": {"name": "team", "visualize": true},
+          "resolved_people_uid_list": [],
+          "jiras": [
+            {"project": "TEST", "types": ["main"]}
+          ],
+          "component_roles": ["auth-service"]
+        }
+      },
+      "platform-team": {
+        "uid": "team-002",
+        "name": "platform-team",
+        "description": "Platform infrastructure team",
+        "type": "team",
+        "parent": {"name": "backend-teams", "type": "team_group"},
+        "group": {
+          "type": {"name": "team", "visualize": true},
+          "resolved_people_uid_list": [],
+          "jiras": [
+            {"project": "PLAT", "types": ["main"]}
+          ],
+          "component_roles": ["platform-api"]
+        }
+      }
+    },
+    "orgs": {
+      "test-org": {
+        "uid": "org-001",
+        "name": "test-org",
+        "description": "Test organization",
+        "type": "org",
+        "group": {
+          "type": {"name": "org", "visualize": true},
+          "resolved_people_uid_list": []
+        }
+      },
+      "platform-org": {
+        "uid": "org-002",
+        "name": "platform-org",
+        "description": "Platform organization",
+        "type": "org",
+        "parent": {"name": "test-org", "type": "org"},
+        "group": {
+          "type": {"name": "org", "visualize": true},
+          "resolved_people_uid_list": []
+        }
+      }
+    },
+    "pillars": {
+      "engineering": {
+        "uid": "pillar-001",
+        "name": "engineering",
+        "description": "Engineering pillar",
+        "type": "pillar",
+        "parent": {"name": "platform-org", "type": "org"},
+        "group": {
+          "type": {"name": "pillar", "visualize": true},
+          "resolved_people_uid_list": []
+        }
+      }
+    },
+    "team_groups": {
+      "backend-teams": {
+        "uid": "tg-001",
+        "name": "backend-teams",
+        "description": "Backend engineering teams",
+        "type": "team_group",
+        "parent": {"name": "engineering", "type": "pillar"},
+        "group": {
+          "type": {"name": "team_group", "visualize": true},
+          "resolved_people_uid_list": []
+        }
+      }
+    },
+    "components": {
+      "platform-api": {
+        "name": "platform-api",
+        "description": "Platform API component",
+        "component": {
+          "type": {"name": "system", "visualize": true}
+        }
+      },
+      "auth-service": {
+        "name": "auth-service",
+        "description": "Authentication service",
+        "component": {
+          "type": {"name": "system", "visualize": true}
+        }
+      }
+    }
+  },
+  "indexes": {
+    "membership": {
+      "membership_index": {}
+    },
+    "slack_id_mappings": {
+      "slack_uid_to_uid": {}
+    },
+    "github_id_mappings": {
+      "github_id_to_uid": {}
+    },
+    "jira": {
+      "TEST": {
+        "Core": [
+          {"name": "test-team", "type": "team"}
+        ]
+      },
+      "PLAT": {
+        "Infrastructure": [
+          {"name": "platform-team", "type": "team"}
+        ]
+      }
+    },
+    "component_ownership": {
+      "platform-api": [
+        {"name": "platform-team", "type": "team", "ownership_types": ["owner"]}
+      ],
+      "auth-service": [
+        {"name": "test-team", "type": "team", "ownership_types": ["owner"]}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The PII-free index produced by orgdata-indexer (openshift-eng/cyborg#294) intentionally has empty `lookups.employees` and `indexes.membership.membership_index`. The validation layer rejects these as invalid data, making PII-free indexes unusable by consumers.

This reads the new `metadata.pii_free` flag and skips employee/membership validation when set.

**Go:**
- Add `PIIFree` field to `Metadata` struct
- Skip `validateData` checks when `PIIFree` is true
- Add `TestLoadPIIFreeData`

**Python:**
- Add `pii_free` field to `Metadata` model
- Skip `_validate_data` checks when `pii_free` is true
- Fix `is_ready()` to return `True` for PII-free data
- Add `TestPIIFreeData` test class


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for organization datasets marked as **PII-free**. The service now validates PII-free inputs appropriately and reports readiness/health based on either employee data availability or the PII-free flag, while keeping team and org lookup behavior intact.

* **Tests**
  * Added a new PII-free dataset fixture and expanded coverage to verify successful loads, readiness/health checks, correct lookup results, and expected failures when PII-free datasets include forbidden employee/member index structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->